### PR TITLE
[機能追加] プレビューサーバー: 3ペインエディタ・タイムライン編集操作・Viewer モード

### DIFF
--- a/packages/preview-server/public/app.js
+++ b/packages/preview-server/public/app.js
@@ -123,6 +123,185 @@ let penActive = false;
 let ws = null;
 let wsTickInterval = null;
 
+// Track management state
+let trackHeadersContainer = null;
+let trackAddBtn = null;
+
+function normalizeTracks(edit) {
+  if (!edit) return;
+  const hasValidVideo = edit.tracks?.some(t => t.type === 'video');
+  if (edit.tracks && edit.tracks.length > 0 && hasValidVideo) {
+    syncLegacyFromTracks(edit);
+    return;
+  }
+  const tracks = [];
+  if (Array.isArray(edit.cuts) && edit.cuts.length > 0) {
+    tracks.push({
+      id: 'trk-video-0',
+      type: 'video',
+      label: 'Video',
+      isMain: true,
+      clips: edit.cuts.map((c, i) => ({
+        id: c.id || `clip-v-${i}`,
+        src: c.src || (edit.sources?.[0]?.id) || 'src-0',
+        in: c.in || 0,
+        out: c.out || (c.in ?? 0) + 1,
+        speed: c.speed || 1,
+        at: c.at,
+        transitionIn: c.transitionIn,
+        transitionOut: c.transitionOut,
+      })),
+      transform: { x: 0, y: 0, scale: 1, rotate: 0 },
+      opacity: 1,
+    });
+  }
+  if (Array.isArray(edit.layers)) {
+    for (const layer of edit.layers) {
+      const lid = layer.id || `trk-video-overlay-${tracks.length}`;
+      tracks.push({
+        id: lid,
+        type: 'video',
+        label: layer.name || layer.id || 'Overlay',
+        isMain: false,
+        clips: [{
+          id: `clip-${lid}`,
+          src: layer.src,
+          in: 0,
+          out: layer.duration || 5,
+          at: layer.t || 0,
+          speed: 1,
+        }],
+        transform: layer.transform || { x: 0, y: 0, scale: 1, rotate: 0 },
+        opacity: layer.opacity ?? 1,
+        blend: layer.blend,
+      });
+    }
+  }
+  if (edit.audio) {
+    if (edit.audio.bgm) {
+      tracks.push({
+        id: 'trk-audio-bgm',
+        type: 'audio',
+        label: 'BGM',
+        clips: [{
+          id: 'clip-bgm',
+          src: edit.audio.bgm.path || edit.audio.bgm.src,
+          at: edit.audio.bgm.t ?? 0,
+          gainDb: edit.audio.bgm.gainDb ?? edit.audio.bgm.gain_db ?? 0,
+          ducking: edit.audio.bgm.ducking ?? false,
+          loop: edit.audio.bgm.loop !== false,
+          fadeIn: edit.audio.bgm.fadeIn,
+          fadeOut: edit.audio.bgm.fadeOut,
+        }],
+      });
+    }
+    if (Array.isArray(edit.audio.narration)) {
+      for (const n of edit.audio.narration) {
+        const existing = tracks.find(t => t.type === 'narration');
+        if (existing) {
+          existing.clips.push({
+            id: n.id || `clip-nar-${existing.clips.length}`,
+            src: n.path || n.src,
+            at: n.t ?? 0,
+            gainDb: n.gainDb ?? 0,
+          });
+        } else {
+          tracks.push({
+            id: 'trk-narration',
+            type: 'narration',
+            label: 'Narration',
+            clips: [{
+              id: n.id || 'clip-nar-0',
+              src: n.path || n.src,
+              at: n.t ?? 0,
+              gainDb: n.gainDb ?? 0,
+            }],
+          });
+        }
+      }
+    }
+    if (Array.isArray(edit.audio.sfx)) {
+      for (const s of edit.audio.sfx) {
+        const existing = tracks.find(t => t.id === 'trk-sfx');
+        if (existing) {
+          existing.clips.push({
+            id: `clip-sfx-${existing.clips.length}`,
+            src: s.path || s.src,
+            at: s.t ?? 0,
+            gainDb: s.gainDb ?? 0,
+          });
+        } else {
+          tracks.push({
+            id: 'trk-sfx',
+            type: 'audio',
+            label: 'SFX',
+            clips: [{
+              id: 'clip-sfx-0',
+              src: s.path || s.src,
+              at: s.t ?? 0,
+              gainDb: s.gainDb ?? 0,
+            }],
+          });
+        }
+      }
+    }
+  }
+  edit.tracks = tracks;
+  syncLegacyFromTracks(edit);
+}
+
+function syncLegacyFromTracks(edit) {
+  if (!edit?.tracks) return;
+  // Ensure first video track has isMain
+  const firstVid = edit.tracks.find(t => t.type === 'video');
+  if (firstVid) firstVid.isMain = true;
+  const mainVid = edit.tracks.find(t => t.type === 'video' && t.isMain) || firstVid;
+  if (mainVid) {
+    edit.cuts = mainVid.clips.map((clip, i) => ({
+      ...(clip.transitionIn ? { transitionIn: clip.transitionIn } : {}),
+      ...(clip.transitionOut ? { transitionOut: clip.transitionOut } : {}),
+      in: clip.in ?? 0,
+      out: clip.out ?? (clip.in ?? 0) + 1,
+      speed: clip.speed || 1,
+      at: clip.at,
+      src: clip.src || (edit.sources?.[0]?.id),
+    }));
+  }
+  const bgmTrack = edit.tracks.find(t => t.type === 'audio' && t.id === 'trk-audio-bgm');
+  const narTrack = edit.tracks.find(t => t.type === 'narration');
+  const sfxTrack = edit.tracks.find(t => t.type === 'audio' && t.id === 'trk-sfx');
+  const audio = {};
+  if (bgmTrack && bgmTrack.clips.length > 0) {
+    const c = bgmTrack.clips[0];
+    audio.bgm = {
+      path: c.src, gain_db: c.gainDb ?? 0,
+      ducking: c.ducking ?? false, loop: c.loop !== false,
+      ...(c.fadeIn !== undefined ? { fadeIn: c.fadeIn } : {}),
+      ...(c.fadeOut !== undefined ? { fadeOut: c.fadeOut } : {}),
+    };
+  }
+  if (narTrack && narTrack.clips.length > 0) {
+    audio.narration = narTrack.clips.map(c => ({
+      id: c.id, path: c.src, t: c.at ?? 0, gainDb: c.gainDb ?? 0,
+    }));
+  }
+  if (sfxTrack && sfxTrack.clips.length > 0) {
+    audio.sfx = sfxTrack.clips.map(c => ({
+      path: c.src, t: c.at ?? 0, gainDb: c.gainDb ?? 0,
+    }));
+  }
+  edit.audio = audio;
+  const overlayTracks = edit.tracks.filter(t => t.type === 'video' && !t.isMain);
+  edit.layers = overlayTracks.map(t => {
+    const c = t.clips?.[0];
+    return {
+      id: t.id, name: t.label, src: c?.src, t: c?.at ?? 0,
+      duration: c ? ((c.out ?? 5) - (c.in ?? 0)) / (c.speed || 1) : 5,
+      transform: t.transform || {}, opacity: t.opacity ?? 1, blend: t.blend,
+    };
+  });
+}
+
 async function init() {
   try {
     const [timelineRes, editRes, captionsRes] = await Promise.all([
@@ -133,6 +312,7 @@ async function init() {
     if (!timelineRes.ok) throw new Error(`timeline: HTTP ${timelineRes.status}`);
     timelineData = await timelineRes.json();
     summary = await editRes.json();
+    normalizeTracks(summary);
     if (captionsRes.ok) {
       const body = await captionsRes.json();
       captionsData = Array.isArray(body) ? body : (body?.captions ?? []);
@@ -182,34 +362,28 @@ function getVideoSource(cutIndex) {
 
 // --- Segments ---
 function buildSegments() {
-  if (!summary?.cuts) return;
+  if (!summary?.tracks?.length) return;
   segments = [];
-  const cutEvents = [];
-  for (let i = 0; i < summary.cuts.length; i++) {
-    const cut = summary.cuts[i];
-    const speed = cut.speed || 1;
-    const inSec = cut.in || 0;
-    const outSec = cut.out || inSec + 1;
-    const dur = (outSec - inSec) / speed;
-    cutEvents.push({ index: i, inSec, outSec, speed, durationSec: dur, track: cut.track ?? 0, at: cut.at });
-  }
-  const trackMap = {};
-  for (const c of cutEvents) {
-    if (!trackMap[c.track]) trackMap[c.track] = [];
-    trackMap[c.track].push(c);
-  }
-  const tracks = Object.keys(trackMap).map(Number).sort((a, b) => a - b);
-  for (const tn of tracks) {
-    const tc = trackMap[tn];
-    let cursor = 0;
-    for (let ci = 0; ci < tc.length; ci++) {
-      const c = tc[ci];
-      if (c.at !== undefined) cursor = c.at;
-      const gap = ci === 0 ? 0 : Math.max(0, cursor - segments.reduce((s, seg) => s + seg.durationSec, 0));
-      if (gap > 0) segments.push({ index: -1, durationSec: gap, isGap: true });
-      segments.push(c);
-      cursor += c.durationSec;
-    }
+  const mainVid = summary.tracks.find(t => t.type === 'video' && t.isMain) || summary.tracks.find(t => t.type === 'video');
+  if (!mainVid) return;
+  const clips = mainVid.clips || [];
+  const sorted = clips.map((clip, i) => ({
+    index: i, clip,
+    inSec: clip.in || 0,
+    outSec: clip.out || (clip.in || 0) + 1,
+    speed: clip.speed || 1,
+    durationSec: ((clip.out || (clip.in || 0) + 1) - (clip.in || 0)) / (clip.speed || 1),
+    trackId: mainVid.id,
+    at: clip.at,
+  }));
+  let cursor = 0;
+  for (let ci = 0; ci < sorted.length; ci++) {
+    const c = sorted[ci];
+    if (c.at !== undefined) cursor = c.at;
+    const gap = ci === 0 ? 0 : Math.max(0, cursor - segments.reduce((s, seg) => s + seg.durationSec, 0));
+    if (gap > 0) segments.push({ index: -1, durationSec: gap, isGap: true });
+    segments.push(c);
+    cursor += c.durationSec;
   }
   totalDuration = segments.reduce((s, seg) => s + seg.durationSec, 0);
   seek.max = totalDuration;
@@ -503,6 +677,7 @@ function setupAudioGraph() {
       bgmNode = gain;
       loadAudioBuffer(bgmUrl).then((buf) => {
         if (!buf) return;
+        bgmNode._buffer = buf;
         const src = audioCtx.createBufferSource();
         src.buffer = buf; src.loop = audio.bgm.loop !== false;
         src.connect(gain);
@@ -582,6 +757,16 @@ function syncAudio(t) {
   }
 }
 
+function recreateBgmSource(t) {
+  if (!bgmNode || !bgmNode._buffer || !audioCtx) return;
+  if (bgmNode._source) { try { bgmNode._source.stop(); } catch {} bgmNode._source = null; }
+  const src = audioCtx.createBufferSource();
+  src.buffer = bgmNode._buffer;
+  src.loop = summary?.audio?.bgm?.loop !== false;
+  src.connect(bgmNode);
+  if (isPlaying) { src.start(0, Math.max(0, t)); src._started = true; }
+  bgmNode._source = src;
+}
 // --- Waveform ---
 async function computePeaks(url, numPeaks) {
   try {
@@ -743,6 +928,8 @@ function seekTo(t) {
   updateOverlays();
   syncAudio(outputTime);
   syncLayers(outputTime);
+  // Recreate BGM source at seeked position
+  if (bgmNode?._buffer && outputTime < totalDuration) recreateBgmSource(outputTime);
 }
 
 function play() {
@@ -750,8 +937,19 @@ function play() {
   logReviewEvent('play');
   isPlaying = true;
   if (audioCtx?.state === 'suspended') audioCtx.resume();
-  if (bgmNode?._source && !bgmNode._source._started) { bgmNode._source.start(); bgmNode._source._started = true; }
+  if (bgmNode?._source) {
+    if (!bgmNode._source._started) { bgmNode._source.start(); bgmNode._source._started = true; }
+    if (bgmNode._savedGain !== undefined) { bgmNode.gain.value = bgmNode._savedGain; delete bgmNode._savedGain; }
+  }
   syncAudio(outputTime);
+  // Seek video before playing to prevent stale-frame flash
+  const pTarget = getVideoTimeForOutput(outputTime);
+  const pSeg = getActiveSegment(outputTime);
+  if (pTarget >= 0 && pSeg && pSeg.index >= 0) {
+    const pSrc = getVideoSource(pSeg.index);
+    if (pSrc && video.src !== pSrc) video.src = pSrc;
+    video.currentTime = pTarget;
+  }
   video.play();
   for (const lv of layerVideos) if (lv.visible) lv.el.play();
   playToggle.innerHTML = pauseIcon;
@@ -764,6 +962,10 @@ function pause() {
   logReviewEvent('pause');
   isPlaying = false; video.pause();
   for (const lv of layerVideos) lv.el.pause();
+  // Mute BGM without destroying source (AudioBufferSourceNode can only start once)
+  if (bgmNode) { bgmNode._savedGain ??= bgmNode.gain.value; bgmNode.gain.value = 0; }
+  for (const n of narrationNodes) { if (n._source) { try { n._source.stop(); } catch {} n._source._ended = true; } }
+  for (const s of sfxNodes) { if (s._source) { try { s._source.stop(); } catch {} s._source._ended = true; } }
   playToggle.innerHTML = playIcon;
   playToggle.setAttribute('aria-label', '再生');
   playToggle.title = '再生';
@@ -898,7 +1100,23 @@ async function reloadSummary() {
   const res = await fetch(api.summary);
   if (!res.ok) throw new Error(`summary: HTTP ${res.status}`);
   summary = await res.json();
+  normalizeTracks(summary);
   return summary;
+}
+
+function syncTracksFromCuts(edit) {
+  const mainVid = edit.tracks?.find(t => t.type === 'video' && t.isMain);
+  if (!mainVid || !edit.cuts) return;
+  mainVid.clips = edit.cuts.map((c, i) => ({
+    id: mainVid.clips[i]?.id || `clip-v-${i}`,
+    src: c.src || (edit.sources?.[0]?.id) || 'src-0',
+    in: c.in || 0,
+    out: c.out || (c.in ?? 0) + 1,
+    speed: c.speed || 1,
+    at: c.at,
+    transitionIn: c.transitionIn,
+    transitionOut: c.transitionOut,
+  }));
 }
 
 function showCutInfoAt(t) {
@@ -1000,9 +1218,11 @@ function renderCutInfoContent(seg) {
     cut.transitionIn = tiType ? { type: tiType, duration: Number.isFinite(tiDur) && tiDur > 0 ? tiDur : 0.3 } : undefined;
     cut.transitionOut = toType ? { type: toType, duration: Number.isFinite(toDur) && toDur > 0 ? toDur : 0.3 } : undefined;
     try {
+      const body = { ...JSON.parse(JSON.stringify(summary)), cuts: newCuts };
+      syncTracksFromCuts(body);
       const res = await fetch('/api/edit.json', {
         method: 'PUT', headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ ...summary, cuts: newCuts })
+        body: JSON.stringify(body)
       });
       if (res.ok) {
         buildSegments();
@@ -1025,9 +1245,11 @@ async function addCutAt(index, where) {
   const newCut = { in: inSec, out: outSec };
   const idx = where === 'before' ? index : index + 1;
   const newCuts = [...cuts.slice(0, idx), newCut, ...cuts.slice(idx)];
+  const body = { ...JSON.parse(JSON.stringify(summary)), cuts: newCuts };
+  syncTracksFromCuts(body);
   const res = await fetch('/api/edit.json', {
     method: 'PUT', headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ ...summary, cuts: newCuts })
+    body: JSON.stringify(body)
   });
   if (res.ok) {
     buildSegments();
@@ -1044,9 +1266,11 @@ async function moveCut(index, dir) {
   if (target < 0 || target >= cuts.length) return;
   const newCuts = [...cuts];
   [newCuts[index], newCuts[target]] = [newCuts[target], newCuts[index]];
+  const body = { ...JSON.parse(JSON.stringify(summary)), cuts: newCuts };
+  syncTracksFromCuts(body);
   const res = await fetch('/api/edit.json', {
     method: 'PUT', headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ ...summary, cuts: newCuts })
+    body: JSON.stringify(body)
   });
   if (res.ok) {
     buildSegments();
@@ -1060,9 +1284,11 @@ async function deleteCut(index) {
   const cuts = summary?.cuts;
   if (!Array.isArray(cuts) || index < 0 || cuts.length <= 1) return;
   const newCuts = [...cuts.slice(0, index), ...cuts.slice(index + 1)];
+  const body = { ...JSON.parse(JSON.stringify(summary)), cuts: newCuts };
+  syncTracksFromCuts(body);
   const res = await fetch('/api/edit.json', {
     method: 'PUT', headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ ...summary, cuts: newCuts })
+    body: JSON.stringify(body)
   });
   if (res.ok) {
     buildSegments();
@@ -1071,7 +1297,6 @@ async function deleteCut(index) {
     showMessage(await editSaveErrorMessage(res));
   }
 }
-
 // Wire seek visual click
 seekVisual.addEventListener('click', (e) => {
   const rect = seek.getBoundingClientRect();
@@ -1084,8 +1309,8 @@ seekVisual.addEventListener('click', (e) => {
 });
 
 playToggle.addEventListener('click', () => isPlaying ? pause() : play());
-frameBack.addEventListener('click', () => { pause(); seekTo(outputTime - 1 / fps); });
-frameForward.addEventListener('click', () => { pause(); seekTo(outputTime + 1 / fps); });
+frameBack.addEventListener('click', () => { pause(); seekTo(0); });
+frameForward.addEventListener('click', () => { pause(); seekTo(totalDuration); });
 skipBack.addEventListener('click', () => { pause(); seekTo(outputTime - 10); });
 skipForward.addEventListener('click', () => { pause(); seekTo(outputTime + 10); });
 seek.addEventListener('input', () => {
@@ -1591,8 +1816,10 @@ async function writeEditJson(kind, id, patch) {
       const ly = edit.layers?.find(l => String(l.id) === String(id));
       if (ly) Object.assign(ly, patch.transform ? { transform: { ...ly.transform, ...patch.transform } } : patch);
     }
+    syncTracksFromCuts(edit);
+    syncLegacyFromTracks(edit);
     const saveRes = await fetch('/api/edit.json', { method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(edit) });
-    if (saveRes.ok) { summary = edit; window.akari?.runtime?.mount(summary); }
+    if (saveRes.ok) { summary = edit; normalizeTracks(summary); window.akari?.runtime?.mount(summary); }
   } catch (e) { console.error('write failed', e); }
 }
 
@@ -1906,7 +2133,10 @@ function connectWs() {
   ws.onmessage = (e) => {
     try {
       const m = JSON.parse(e.data);
-      if (m.type === 'reload') return location.reload();
+      if (m.type === 'reload') {
+        reloadSummary().then(() => { buildSegments(); seekTo(outputTime); renderTimeline(); }).catch(() => location.reload());
+        return;
+      }
       if (m.type === 'captions-reload') {
         fetch(api.summary).then(r => r.ok && r.json()).then(d => { if (d) summary = d; }).catch(() => {});
         return;
@@ -2097,6 +2327,121 @@ function setupAssetBrowser() {
     if (!item) return;
     showMessage(null);
   });
+
+  // Asset context menu (right-click)
+  const assetCtx = document.getElementById('asset-ctx-menu');
+  assetCtx.addEventListener('contextmenu', e => e.preventDefault());
+
+  const CATEGORY_TYPE = {
+    video: { defaultType: 'video', typeLocked: true },
+    audio: { defaultType: 'audio', typeLocked: false, typeFilter: ['audio', 'narration', 'sfx'] },
+    image: { defaultType: 'video', typeLocked: true },
+  };
+
+  function buildAssetCtxMenu(path, name, category) {
+    const otherTracks = (summary?.tracks || []).filter(t => !t.isMain);
+    let html = `<button class="ctx-actx" data-action="main">メインタイムラインに追加</button>`;
+    if (otherTracks.length > 0) {
+      html += `<div class="ctx-section-title">既存トラックに追加:</div>`;
+      for (const t of otherTracks) {
+        html += `<button class="ctx-actx" data-action="track" data-id="${t.id}">${esc(t.label)}</button>`;
+      }
+    }
+    html += `<button class="ctx-actx" data-action="new">＋ 新規トラックを作成し追加</button>`;
+    html += `<hr><button class="ctx-actx" data-action="copy">ファイル名をコピー</button>`;
+    assetCtx.innerHTML = html;
+    assetCtx._path = path;
+    assetCtx._name = name;
+    assetCtx._category = category;
+  }
+
+  assetList.addEventListener('contextmenu', (e) => {
+    const item = e.target.closest('.asset-item');
+    if (!item) return;
+    e.preventDefault();
+    const path = item.dataset.path;
+    const name = item.querySelector('.asset-name')?.textContent || '';
+    const category = item.dataset.category || 'video';
+    buildAssetCtxMenu(path, name, category);
+    assetCtx.style.left = `${e.clientX}px`;
+    assetCtx.style.top = `${e.clientY}px`;
+    assetCtx.hidden = false;
+  });
+
+  assetCtx.addEventListener('click', async (e) => {
+    const btn = e.target.closest('.ctx-actx');
+    if (!btn) return;
+    const action = btn.dataset.action;
+    const path = assetCtx._path;
+    const name = assetCtx._name;
+    const category = assetCtx._category;
+    assetCtx.hidden = true;
+
+    if (action === 'copy') {
+      if (!name) return;
+      try { await navigator.clipboard.writeText(name); showMessage('ファイル名をコピーしました'); }
+      catch { showMessage('コピーに失敗しました'); }
+      return;
+    }
+
+    if (!path || !summary?.cuts) return;
+    const t = outputTime;
+    const srcId = 'src-' + Date.now();
+
+    if (action === 'main') {
+      const newEdit = ensureV1(JSON.parse(JSON.stringify(summary)));
+      newEdit.sources.push({ id: srcId, path });
+      newEdit.cuts = [...newEdit.cuts, { in: 0, out: 2, src: srcId, at: +t.toFixed(2) }];
+      try {
+        syncTracksFromCuts(newEdit);
+        const res = await fetch('/api/edit.json', {
+          method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(newEdit)
+        });
+        if (res.ok) { await reloadSummary(); buildSegments(); seekTo(outputTime); showMessage('メインタイムラインに追加しました'); }
+        else showMessage(await editSaveErrorMessage(res));
+      } catch (err) { showMessage(err?.message || String(err)); }
+      return;
+    }
+
+    if (action === 'new') {
+      const ct = CATEGORY_TYPE[category] || CATEGORY_TYPE.video;
+      const result = await showAddTrackDialog({ ...ct, defaultName: '' });
+      if (!result) return;
+      const { type, name: trackName } = result;
+      const edit = JSON.parse(JSON.stringify(summary));
+      edit.sources.push({ id: srcId, path });
+      const count = edit.tracks.filter(t => t.type === type && !t.isMain).length;
+      const nid = `trk-${type}-${Date.now()}`;
+      const track = { id: nid, type, label: trackName, isMain: false, clips: [] };
+      if (type === 'video') { track.transform = { x: 0, y: 0, scale: 0.3, rotate: 0 }; track.opacity = 1; }
+      track.clips.push({ id: `clip-${nid}`, src: srcId, in: 0, out: 2, at: +t.toFixed(2), speed: 1 });
+      edit.tracks.push(track);
+      try {
+        const res = await fetch('/api/edit.json', {
+          method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(edit)
+        });
+        if (res.ok) { await reloadSummary(); buildSegments(); seekTo(outputTime); showMessage(`トラック「${trackName}」に追加しました`); }
+        else showMessage(await editSaveErrorMessage(res));
+      } catch (err) { showMessage(err?.message || String(err)); }
+      return;
+    }
+
+    // action === 'track' — add to existing track
+    const edit = JSON.parse(JSON.stringify(summary));
+    edit.sources.push({ id: srcId, path });
+    const trackId = btn.dataset.id;
+    const track = edit.tracks.find(t => t.id === trackId);
+    if (track) {
+      track.clips.push({ id: `clip-${trackId}-${Date.now()}`, src: srcId, in: 0, out: 2, at: +t.toFixed(2), speed: 1 });
+      try {
+        const res = await fetch('/api/edit.json', {
+          method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(edit)
+        });
+        if (res.ok) { await reloadSummary(); buildSegments(); seekTo(outputTime); showMessage('トラックに追加しました'); }
+        else showMessage(await editSaveErrorMessage(res));
+      } catch (err) { showMessage(err?.message || String(err)); }
+    }
+  });
   // Drag-and-drop upload
   const assetPane = document.getElementById('asset-pane');
   let dropOverlay = null;
@@ -2144,6 +2489,23 @@ function setupAssetBrowser() {
   });
 }
 
+function ensureV1(edit) {
+  if (edit.source && !Array.isArray(edit.sources)) {
+    edit.version = 1;
+    const id = 'src-main-' + Date.now();
+    const srcObj = typeof edit.source === 'string' ? {} : edit.source;
+    edit.sources = [{ id, path: srcObj.path, proxy: srcObj.proxy || null }];
+    delete edit.source;
+    let at = 0;
+    edit.cuts = (edit.cuts || []).map(c => {
+      const cut = { ...c, src: id, at: +at.toFixed(3) };
+      at += (c.out - c.in);
+      return cut;
+    });
+  }
+  return edit;
+}
+
 async function loadAssets() {
   try {
     const res = await fetch('/api/project-files');
@@ -2151,6 +2513,114 @@ async function loadAssets() {
     allAssets = await res.json();
     renderAssets();
   } catch {}
+}
+
+// --- Track management ---
+const TYPE_OPTIONS = [
+  { value: 'video', label: 'ビデオ（オーバーレイ）' },
+  { value: 'audio', label: 'ミュージック' },
+  { value: 'narration', label: 'ナレーション' },
+  { value: 'sfx', label: '効果音' },
+];
+
+function showAddTrackDialog(opts) {
+  return new Promise((resolve) => {
+    const dialog = document.getElementById('add-track-dialog');
+    const typeSel = document.getElementById('atd-type');
+    const nameInp = document.getElementById('atd-name');
+    const okBtn = document.getElementById('atd-ok');
+    const cancelBtn = document.getElementById('atd-cancel');
+
+    // Filter type options if requested
+    const filtered = opts.typeFilter ? TYPE_OPTIONS.filter(o => opts.typeFilter.includes(o.value)) : TYPE_OPTIONS;
+    typeSel.innerHTML = filtered.map(o => `<option value="${o.value}">${o.label}</option>`).join('');
+    typeSel.value = opts.defaultType || filtered[0]?.value || 'video';
+    typeSel.disabled = !!opts.typeLocked;
+    nameInp.value = opts.defaultName || '';
+    nameInp.placeholder = opts.defaultName ? '' : 'トラック名を入力';
+
+    function cleanup() {
+      dialog.hidden = true;
+      okBtn.removeEventListener('click', onOk);
+      cancelBtn.removeEventListener('click', onCancel);
+      dialog.removeEventListener('keydown', onKey);
+    }
+    function onOk() {
+      const type = typeSel.value;
+      const name = nameInp.value.trim() || typeSel.options[typeSel.selectedIndex].text;
+      cleanup();
+      resolve({ type, name });
+    }
+    function onCancel() {
+      cleanup();
+      resolve(null);
+    }
+    function onKey(e) {
+      if (e.key === 'Escape') onCancel();
+      if (e.key === 'Enter') onOk();
+    }
+    okBtn.addEventListener('click', onOk);
+    cancelBtn.addEventListener('click', onCancel);
+    dialog.addEventListener('keydown', onKey);
+
+    dialog.hidden = false;
+    setTimeout(() => nameInp.focus(), 100);
+  });
+}
+
+function addTrack() {
+  if (!summary?.tracks) return;
+  showAddTrackDialog({ defaultType: 'video', defaultName: '' }).then(result => {
+    if (!result) return;
+    const { type, name } = result;
+    const count = summary.tracks.filter(t => t.type === type && !t.isMain).length;
+    const nid = `trk-${type}-${Date.now()}`;
+    const base = { id: nid, label: name, isMain: false };
+    let newTrack;
+    if (type === 'video') {
+      newTrack = { ...base, type: 'video', clips: [], transform: { x: 0, y: 0, scale: 0.3, rotate: 0 }, opacity: 1 };
+    } else {
+      newTrack = { ...base, type, clips: [] };
+    }
+    if (!newTrack) return;
+    summary.tracks.push(newTrack);
+    syncLegacyFromTracks(summary);
+    buildSegments();
+    showMessage(`トラック「${name}」を追加しました`);
+  });
+}
+
+async function removeTrack(trackId) {
+  if (!summary?.tracks) return;
+  const idx = summary.tracks.findIndex(t => t.id === trackId);
+  if (idx < 0) return;
+  const track = summary.tracks[idx];
+  if (track.isMain) { showMessage('メインビデオトラックは削除できません'); return; }
+  summary.tracks.splice(idx, 1);
+  syncLegacyFromTracks(summary);
+  try {
+    const res = await fetch('/api/edit.json', {
+      method: 'PUT', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(summary)
+    });
+    if (res.ok) { await reloadSummary(); buildSegments(); showMessage(`トラック「${track.label}」を削除しました`); }
+    else showMessage(await editSaveErrorMessage(res));
+  } catch (e) { showMessage(e?.message || String(e)); }
+}
+
+async function renameTrack(trackId, newLabel) {
+  if (!summary?.tracks) return;
+  const track = summary.tracks.find(t => t.id === trackId);
+  if (!track) return;
+  track.label = newLabel;
+  try {
+    const res = await fetch('/api/edit.json', {
+      method: 'PUT', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(summary)
+    });
+    if (res.ok) { await reloadSummary(); buildSegments(); }
+    else showMessage(await editSaveErrorMessage(res));
+  } catch (e) { showMessage(e?.message || String(e)); }
 }
 
 // --- Timeline Editor ---
@@ -2188,25 +2658,47 @@ function tlTimeFromX(px) {
 }
 
 function tlHitTest(px, py) {
-  if (py < 0 || py > TL_TRACK_HEIGHT * 2) return null;
-  const track = py < TL_TRACK_HEIGHT ? 0 : 1;
-  let cursor = 0;
-  for (let i = 0; i < segments.length; i++) {
-    const seg = segments[i];
-    if (seg.isGap) { cursor += seg.durationSec; continue; }
-    if (seg.track !== track) { cursor += seg.durationSec; continue; }
-    const sx = cursor * tlZoom;
-    const sw = seg.durationSec * tlZoom;
-    if (px >= sx && px < sx + sw) {
-      const distL = px - sx;
-      const distR = (sx + sw) - px;
-      let mode;
-      if (distL < TL_HANDLE_PX && sw > TL_HANDLE_PX * 2) mode = 'trim-in';
-      else if (distR < TL_HANDLE_PX && sw > TL_HANDLE_PX * 2) mode = 'trim-out';
-      else mode = 'move';
-      return { segIndex: i, cutIndex: seg.index, mode, cursor };
+  const numTracks = getTimelineTrackCount();
+  if (py < 0 || py > TL_TRACK_HEIGHT * numTracks) return null;
+  const trackN = Math.floor(py / TL_TRACK_HEIGHT);
+  const tracks = summary?.tracks?.filter(t => t.type === 'video') || [];
+  const track = tracks[trackN];
+  if (!track) return null;
+  if (track.isMain) {
+    // Main track hit test using segments
+    let cursor = 0;
+    for (let i = 0; i < segments.length; i++) {
+      const seg = segments[i];
+      if (seg.isGap) { cursor += seg.durationSec; continue; }
+      const sx = cursor * tlZoom;
+      const sw = seg.durationSec * tlZoom;
+      if (px >= sx && px < sx + sw) {
+        const distL = px - sx;
+        const distR = (sx + sw) - px;
+        let mode;
+        if (distL < TL_HANDLE_PX && sw > TL_HANDLE_PX * 2) mode = 'trim-in';
+        else if (distR < TL_HANDLE_PX && sw > TL_HANDLE_PX * 2) mode = 'trim-out';
+        else mode = 'move';
+        return { segIndex: i, cutIndex: seg.index, mode, cursor, trackId: track.id };
+      }
+      cursor += seg.durationSec;
     }
-    cursor += seg.durationSec;
+  } else {
+    // Overlay track: hit test on clips directly
+    let cursor = 0;
+    for (let ci = 0; ci < track.clips.length; ci++) {
+      const clip = track.clips[ci];
+      const inSec = clip.in || 0;
+      const outSec = clip.out || inSec + 1;
+      const dur = (outSec - inSec) / (clip.speed || 1);
+      const at = clip.at !== undefined ? clip.at : cursor;
+      const sx = at * tlZoom;
+      const sw = Math.max(2, dur * tlZoom);
+      if (px >= sx && px < sx + sw) {
+        return { segIndex: -1, cutIndex: -1, mode: 'move', cursor: at, trackId: track.id, clipIndex: ci, isOverlay: true };
+      }
+      cursor = at + dur;
+    }
   }
   return null;
 }
@@ -2246,6 +2738,7 @@ async function tlSplitCut(t) {
   const cutB = { ...orig, in: +srcSplit.toFixed(3), at: +t.toFixed(3) };
   newEdit.cuts.splice(seg.index, 1, cutA, cutB);
   try {
+    syncTracksFromCuts(newEdit);
     const res = await fetch('/api/edit.json', {
       method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(newEdit)
     });
@@ -2260,6 +2753,7 @@ async function tlDeleteCut(t) {
   const newEdit = JSON.parse(JSON.stringify(summary));
   newEdit.cuts.splice(seg.index, 1);
   try {
+    syncTracksFromCuts(newEdit);
     const res = await fetch('/api/edit.json', {
       method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(newEdit)
     });
@@ -2273,6 +2767,15 @@ function setupTimeline() {
   tlZoomOut.addEventListener('click', () => { tlZoom = Math.max(TL_MIN_ZOOM, tlZoom / 1.5); renderTimeline(); });
   tlFitBtn.addEventListener('click', () => { tlZoom = computeNaturalZoom(); renderTimeline(); });
   tlCanvasWrap.addEventListener('scroll', () => { tlScrollLeft = tlCanvasWrap.scrollLeft; updateTimelinePlayhead(); });
+
+  // Add track button — near タイムライン label
+  const addTrackBtn = document.createElement('button');
+  addTrackBtn.className = 'tl-btn';
+  addTrackBtn.textContent = '+';
+  addTrackBtn.title = 'トラックを追加';
+  addTrackBtn.style.cssText = 'margin-left:4px;font-weight:bold';
+  addTrackBtn.addEventListener('click', () => addTrack());
+  document.querySelector('#timeline-pane .pane-header span')?.after(addTrackBtn);
 
   // Pointer interaction: trim / move / seek
   tlCanvas.addEventListener('pointerdown', (e) => {
@@ -2295,13 +2798,42 @@ function setupTimeline() {
       startPx: px,
       startIn: cut.in, startOut: cut.out,
       startSegIn: seg.inSec, startSegOut: seg.outSec,
-      startAt: cut.at !== undefined ? cut.at : null,
+      startAt: cut.at !== undefined ? cut.at : hit.cursor,
       saved: false, moved: false,
       cursorStart: hit.cursor,
     };
     tlCanvas.setPointerCapture(e.pointerId);
     e.preventDefault();
   });
+
+  document.getElementById('ctx-menu').addEventListener('contextmenu', e => e.preventDefault());
+
+  tlCanvas.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
+    const px = tlTimelineX(e);
+    const py = e.clientY - tlCanvas.getBoundingClientRect().top;
+    const hit = tlHitTest(px, py);
+    const seg = hit ? segments[hit.segIndex] : null;
+    const ctxMenu = document.getElementById('ctx-menu');
+    const ctxTime = hit ? tlTimeFromX(px) : outputTime;
+    ctxMenu._segIndex = hit?.segIndex ?? -1;
+    ctxMenu._cutIndex = hit?.cutIndex ?? -1;
+    ctxMenu._time = ctxTime;
+    ctxMenu.style.left = `${e.clientX}px`;
+    ctxMenu.style.top = `${e.clientY}px`;
+    ctxMenu.hidden = false;
+    document.getElementById('ctx-split').disabled = !seg || seg.isGap;
+    document.getElementById('ctx-delete').disabled = !seg || seg.isGap;
+    document.getElementById('ctx-add-before').disabled = hit?.cutIndex < 0;
+    document.getElementById('ctx-add-after').disabled = hit?.cutIndex < 0;
+    document.getElementById('ctx-move-up').disabled = hit?.cutIndex <= 0;
+    document.getElementById('ctx-move-down').disabled = hit?.cutIndex < 0 || hit?.cutIndex >= (summary?.cuts?.length ?? 0) - 1;
+  });
+
+  document.addEventListener('click', (e) => {
+    const ctxMenu = document.getElementById('ctx-menu');
+    if (!ctxMenu.hidden && !ctxMenu.contains(e.target)) ctxMenu.hidden = true;
+  }, { capture: true });
 
   tlCanvas.addEventListener('pointermove', (e) => {
     if (!tlDrag) {
@@ -2404,6 +2936,7 @@ function setupTimeline() {
       cut.at = Math.max(0, +(tlDrag.startAt + deltaSec).toFixed(2));
     }
     try {
+      syncTracksFromCuts(newEdit);
       const res = await fetch('/api/edit.json', {
         method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(newEdit)
       });
@@ -2459,12 +2992,12 @@ function setupTimeline() {
     const assetPath = e.dataTransfer.getData('text/plain');
     if (!assetPath || !summary?.cuts) return;
     const t = tlTimeFromX(tlTimelineX(e));
-    const newEdit = JSON.parse(JSON.stringify(summary));
-    if (!Array.isArray(newEdit.sources)) newEdit.sources = [];
+    const newEdit = ensureV1(JSON.parse(JSON.stringify(summary)));
     const srcId = 'src-' + Date.now();
     newEdit.sources.push({ id: srcId, path: assetPath });
     newEdit.cuts = [...newEdit.cuts, { in: 0, out: 2, src: srcId, at: +t.toFixed(2) }];
     try {
+      syncTracksFromCuts(newEdit);
       const res = await fetch('/api/edit.json', {
         method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(newEdit)
       });
@@ -2474,10 +3007,74 @@ function setupTimeline() {
   });
 }
 
+function renderTrackHeaders() {
+  const headers = document.getElementById('tl-headers');
+  if (!headers) return;
+  const tracks = summary?.tracks?.filter(t => t.type === 'video') || [];
+  let html = `<div class="timeline-track-header" style="height:22px"></div>`;
+  for (const t of tracks) {
+    const isM = t.isMain ? ' ★' : '';
+    html += `<div class="timeline-track-header" data-track-id="${t.id}">${t.label}${isM}</div>`;
+  }
+  headers.innerHTML = html;
+  // Context menu for non-main tracks
+  if (!trackHeaderCtxInitialized) {
+    trackHeaderCtxInitialized = true;
+    headers.addEventListener('contextmenu', (e) => {
+      const header = e.target.closest('.timeline-track-header[data-track-id]');
+      if (!header) return;
+      const trackId = header.dataset.trackId;
+      const track = summary?.tracks?.find(t => t.id === trackId);
+      if (!track || track.isMain) return;
+      e.preventDefault();
+      const ctx = document.getElementById('ctx-menu');
+      ctx.innerHTML = `
+        <button id="ctx-remove-track">トラックを削除</button>
+        <button id="ctx-rename-track">リネーム</button>
+        <hr>
+        <button id="ctx-add-track">トラックを追加</button>
+      `;
+      ctx._trackId = trackId;
+      ctx.style.left = e.clientX + 'px';
+      ctx.style.top = e.clientY + 'px';
+      ctx.hidden = false;
+      document.getElementById('ctx-remove-track').addEventListener('click', () => {
+        ctx.hidden = true;
+        removeTrack(ctx._trackId);
+      }, { once: true });
+      document.getElementById('ctx-rename-track').addEventListener('click', () => {
+        ctx.hidden = true;
+        const newLabel = prompt('新しいトラック名:', track.label);
+        if (newLabel && newLabel.trim()) renameTrack(trackId, newLabel.trim());
+      }, { once: true });
+      document.getElementById('ctx-add-track').addEventListener('click', () => {
+        ctx.hidden = true;
+        addTrack();
+      }, { once: true });
+    });
+  }
+}
+let trackHeaderCtxInitialized = false;
+
+function getTimelineTrackCount() {
+  return (summary?.tracks?.filter(t => t.type === 'video') || []).length || 1;
+}
+
+function getTrackY(trackId) {
+  const tracks = summary?.tracks?.filter(t => t.type === 'video') || [];
+  const idx = tracks.findIndex(t => t.id === trackId);
+  return idx >= 0 ? idx * TL_TRACK_HEIGHT : 0;
+}
+
+function computeTimelineHeight() {
+  return TL_TRACK_HEIGHT * Math.max(1, getTimelineTrackCount());
+}
+
 function renderTimeline() {
   const wrapW = tlCanvasWrap.clientWidth;
   const totalPx = Math.max(wrapW, totalDuration * tlZoom);
-  const h = TL_TRACK_HEIGHT * 2;
+  const numTracks = getTimelineTrackCount();
+  const h = TL_TRACK_HEIGHT * numTracks;
   tlCanvas.width = Math.ceil(totalPx) * devicePixelRatio;
   tlCanvas.height = h * devicePixelRatio;
   tlCanvas.style.width = Math.ceil(totalPx) + 'px';
@@ -2494,65 +3091,89 @@ function renderTimeline() {
     const x = t * tlZoom;
     ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, h); ctx.stroke();
   }
-  // Draw cuts with handles
-  let cursor = 0;
-  for (let i = 0; i < segments.length; i++) {
-    const seg = segments[i];
-    if (seg.isGap) { cursor += seg.durationSec; continue; }
-    const sx = cursor * tlZoom;
-    const sw = seg.durationSec * tlZoom;
-    const color = TL_CUT_COLORS[seg.index % TL_CUT_COLORS.length];
-    const y = seg.track === 0 ? 0 : TL_TRACK_HEIGHT;
-    const segH = TL_TRACK_HEIGHT - 4;
-    // Main body
-    const grad = ctx.createLinearGradient(sx, y, sx, y + TL_TRACK_HEIGHT);
-    grad.addColorStop(0, color);
-    grad.addColorStop(0.5, color);
-    grad.addColorStop(1, '#000');
-    ctx.fillStyle = grad;
-    ctx.beginPath();
-    const r = 3;
-    const rx = sx, ry = y + 2, rw = Math.max(2, sw), rh = segH;
-    ctx.moveTo(rx + r, ry); ctx.lineTo(rx + rw - r, ry); ctx.quadraticCurveTo(rx + rw, ry, rx + rw, ry + r);
-    ctx.lineTo(rx + rw, ry + rh - r); ctx.quadraticCurveTo(rx + rw, ry + rh, rx + rw - r, ry + rh);
-    ctx.lineTo(rx + r, ry + rh); ctx.quadraticCurveTo(rx, ry + rh, rx, ry + rh - r);
-    ctx.lineTo(rx, ry + r); ctx.quadraticCurveTo(rx, ry, rx + r, ry);
-    ctx.fill();
-    // Handle zones
-    if (sw > TL_HANDLE_PX * 3) {
-      ctx.fillStyle = 'rgba(0,0,0,0.25)';
-      ctx.fillRect(sx, y + 2, TL_HANDLE_PX, segH);
-      ctx.fillRect(sx + sw - TL_HANDLE_PX, y + 2, TL_HANDLE_PX, segH);
-      // Handle grips
-      ctx.fillStyle = 'rgba(255,255,255,0.3)';
-      for (let g = 0; g < 3; g++) {
-        const gh = y + 2 + 5 + g * 6;
-        ctx.fillRect(sx + 2, gh, 4, 2);
-        ctx.fillRect(sx + sw - 6, gh, 4, 2);
-      }
-    }
-    // Label
-    if (sw > 30) {
-      ctx.fillStyle = '#fff';
-      ctx.font = '10px system-ui, sans-serif';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      ctx.fillText(`#${seg.index + 1}`, sx + sw / 2, y + TL_TRACK_HEIGHT / 2);
-    }
-    // Source time label (in/out)
-    if (sw > 80) {
-      ctx.fillStyle = 'rgba(255,255,255,0.4)';
-      ctx.font = '8px system-ui, sans-serif';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'bottom';
-      const fmt = (sec) => { const m = Math.floor(sec / 60); return `${m}:${String(Math.floor(sec % 60)).padStart(2, '0')}.${String(Math.floor((sec % 1) * 100)).padStart(2, '0')}`; };
-      ctx.fillText(`${fmt(seg.inSec)} → ${fmt(seg.outSec)}`, sx + sw / 2, y + 1);
-    }
-    cursor += seg.durationSec;
-  }
-  // Track separator
+  // Track separator lines
   ctx.strokeStyle = '#303030';
-  ctx.beginPath(); ctx.moveTo(0, TL_TRACK_HEIGHT); ctx.lineTo(totalPx, TL_TRACK_HEIGHT); ctx.stroke();
+  for (let tn = 1; tn < numTracks; tn++) {
+    const y = tn * TL_TRACK_HEIGHT;
+    ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(totalPx, y); ctx.stroke();
+  }
+  // Draw clips for each video track
+  const videoTracks = summary?.tracks?.filter(t => t.type === 'video') || [];
+  for (const track of videoTracks) {
+    const tY = getTrackY(track.id);
+    const segH = TL_TRACK_HEIGHT - 4;
+    let cursor = 0;
+    let cursorAcc = 0;
+    for (let ci = 0; ci < track.clips.length; ci++) {
+      const clip = track.clips[ci];
+      const inSec = clip.in || 0;
+      const outSec = clip.out || inSec + 1;
+      const speed = clip.speed || 1;
+      const dur = (outSec - inSec) / speed;
+      const at = clip.at;
+      // Position: if at is specified, use it; else sequential
+      let clipStart;
+      if (at !== undefined) {
+        clipStart = at;
+        cursorAcc = at;
+      } else {
+        clipStart = cursor;
+      }
+      // Gap if not contiguous
+      if (ci > 0 && at !== undefined) {
+        // gap is handled by at positioning
+      }
+      const segIndex = track.isMain ? ci : -1;
+      const sx = clipStart * tlZoom;
+      const sw = Math.max(2, dur * tlZoom);
+      const color = track.isMain ? TL_CUT_COLORS[ci % TL_CUT_COLORS.length] : '#6ab04c';
+      // Draw clip body
+      const grad = ctx.createLinearGradient(sx, tY, sx, tY + TL_TRACK_HEIGHT);
+      grad.addColorStop(0, color);
+      grad.addColorStop(0.5, color);
+      grad.addColorStop(1, '#000');
+      ctx.fillStyle = grad;
+      const rx = sx, ry = tY + 2, rw = sw, rh = segH;
+      const r = 3;
+      ctx.beginPath();
+      ctx.moveTo(rx + r, ry); ctx.lineTo(rx + rw - r, ry); ctx.quadraticCurveTo(rx + rw, ry, rx + rw, ry + r);
+      ctx.lineTo(rx + rw, ry + rh - r); ctx.quadraticCurveTo(rx + rw, ry + rh, rx + rw - r, ry + rh);
+      ctx.lineTo(rx + r, ry + rh); ctx.quadraticCurveTo(rx, ry + rh, rx, ry + rh - r);
+      ctx.lineTo(rx, ry + r); ctx.quadraticCurveTo(rx, ry, rx + r, ry);
+      ctx.fill();
+      // Handles on main track
+      if (track.isMain && sw > TL_HANDLE_PX * 3) {
+        ctx.fillStyle = 'rgba(0,0,0,0.25)';
+        ctx.fillRect(sx, tY + 2, TL_HANDLE_PX, segH);
+        ctx.fillRect(sx + sw - TL_HANDLE_PX, tY + 2, TL_HANDLE_PX, segH);
+        ctx.fillStyle = 'rgba(255,255,255,0.3)';
+        for (let g = 0; g < 3; g++) {
+          const gh = tY + 2 + 5 + g * 6;
+          ctx.fillRect(sx + 2, gh, 4, 2);
+          ctx.fillRect(sx + sw - 6, gh, 4, 2);
+        }
+      }
+      // Label
+      if (sw > 30) {
+        ctx.fillStyle = '#fff';
+        ctx.font = '10px system-ui, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        const label = track.isMain ? `#${ci + 1}` : (clip.id ? clip.id.slice(0, 8) : '');
+        ctx.fillText(label, sx + sw / 2, tY + TL_TRACK_HEIGHT / 2);
+      }
+      if (track.isMain && sw > 80) {
+        ctx.fillStyle = 'rgba(255,255,255,0.4)';
+        ctx.font = '8px system-ui, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'bottom';
+        const fmt = (sec) => { const m = Math.floor(sec / 60); return `${m}:${String(Math.floor(sec % 60)).padStart(2, '0')}.${String(Math.floor((sec % 1) * 100)).padStart(2, '0')}`; };
+        ctx.fillText(`${fmt(inSec)} → ${fmt(outSec)}`, sx + sw / 2, tY + 1);
+      }
+      cursor = clipStart + dur;
+      if (at === undefined) cursorAcc = cursor;
+    }
+  }
   // Ruler
   tlRulerCanvas.width = Math.ceil(totalPx) * devicePixelRatio;
   tlRulerCanvas.height = 22 * devicePixelRatio;
@@ -2589,6 +3210,7 @@ function renderTimeline() {
       ctx.fillRect(dx, 0, 40, h);
     }
   }
+  renderTrackHeaders();
   updateTimelinePlayhead();
 }
 
@@ -2597,7 +3219,7 @@ function updateTimelinePlayhead() {
   tlPlayhead.style.display = 'block';
   const x = outputTime * tlZoom - tlCanvasWrap.scrollLeft;
   tlPlayhead.style.left = Math.max(0, x) + 'px';
-  tlPlayhead.style.height = (TL_TRACK_HEIGHT * 2) + 'px';
+  tlPlayhead.style.height = computeTimelineHeight() + 'px';
 }
 
 // Extend existing functions
@@ -2640,5 +3262,9 @@ window.__test = {
   get summary() { return summary; },
   get segments() { return segments; },
   get outputTime() { return outputTime; },
+  get totalDuration() { return totalDuration; },
+  get isPlaying() { return isPlaying; },
   seekTo, getActiveSegment, tlSplitCut, tlDeleteCut,
+  addTrack, removeTrack, renderTrackHeaders,
+  normalizeTracks, syncTracksFromCuts,
 };

--- a/packages/preview-server/public/app.js
+++ b/packages/preview-server/public/app.js
@@ -1118,6 +1118,9 @@ document.addEventListener('keydown', (e) => {
     case 'ArrowDown': e.preventDefault(); pause(); seekTo(outputTime + 10); break;
     case 'Home': e.preventDefault(); seekTo(0); break;
     case 'End': e.preventDefault(); seekTo(totalDuration); break;
+    case 'KeyS': e.preventDefault(); pause(); tlSplitCut(outputTime); break;
+    case 'Delete':
+    case 'Backspace': e.preventDefault(); pause(); tlDeleteCut(outputTime); break;
     case 'Comma': e.preventDefault(); pause(); seekTo(snapToCut(outputTime - 0.1, -1)); break;
     case 'Period': e.preventDefault(); pause(); seekTo(snapToCut(outputTime + 0.1, 1)); break;
     case 'Slash': if (!e.shiftKey) { e.preventDefault(); shortcutHelp.hidden = !shortcutHelp.hidden; } break;
@@ -2208,6 +2211,63 @@ function tlHitTest(px, py) {
   return null;
 }
 
+const TL_SNAP_PX = 6;
+
+function tlSnapTime(t, excludeIndex) {
+  let bestSnap = null;
+  let bestDist = TL_SNAP_PX / tlZoom;
+  let cursor = 0;
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    if (seg.isGap) { cursor += seg.durationSec; continue; }
+    if (seg.index === excludeIndex) { cursor += seg.durationSec; continue; }
+    [cursor, cursor + seg.durationSec].forEach(b => {
+      const d = Math.abs(t - b);
+      if (d < bestDist) { bestDist = d; bestSnap = b; }
+    });
+    cursor += seg.durationSec;
+  }
+  return bestSnap;
+}
+
+async function tlSplitCut(t) {
+  const seg = getActiveSegment(t);
+  if (!seg || seg.isGap || !summary?.cuts?.[seg.index]) return;
+  let cursor = 0;
+  for (const s of segments) {
+    if (s === seg) break;
+    cursor += s.durationSec;
+  }
+  const srcSplit = seg.inSec + (t - cursor) * seg.speed;
+  if (srcSplit <= seg.inSec || srcSplit >= seg.outSec) return;
+  const newEdit = JSON.parse(JSON.stringify(summary));
+  const orig = newEdit.cuts[seg.index];
+  const cutA = { ...orig, out: +srcSplit.toFixed(3) };
+  const cutB = { ...orig, in: +srcSplit.toFixed(3), at: +t.toFixed(3) };
+  newEdit.cuts.splice(seg.index, 1, cutA, cutB);
+  try {
+    const res = await fetch('/api/edit.json', {
+      method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(newEdit)
+    });
+    if (res.ok) { await reloadSummary(); buildSegments(); seekTo(t); showMessage('カットを分割しました (S)'); }
+    else showMessage(await editSaveErrorMessage(res));
+  } catch (err) { showMessage(err?.message || String(err)); }
+}
+
+async function tlDeleteCut(t) {
+  const seg = getActiveSegment(t);
+  if (!seg || seg.isGap || !summary?.cuts?.[seg.index]) return;
+  const newEdit = JSON.parse(JSON.stringify(summary));
+  newEdit.cuts.splice(seg.index, 1);
+  try {
+    const res = await fetch('/api/edit.json', {
+      method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(newEdit)
+    });
+    if (res.ok) { await reloadSummary(); buildSegments(); seekTo(t); showMessage('カットを削除しました (Del)'); }
+    else showMessage(await editSaveErrorMessage(res));
+  } catch (err) { showMessage(err?.message || String(err)); }
+}
+
 function setupTimeline() {
   tlZoomIn.addEventListener('click', () => { tlZoom = Math.min(TL_MAX_ZOOM, tlZoom * 1.5); renderTimeline(); });
   tlZoomOut.addEventListener('click', () => { tlZoom = Math.max(TL_MIN_ZOOM, tlZoom / 1.5); renderTimeline(); });
@@ -2250,6 +2310,24 @@ function setupTimeline() {
       const py = e.offsetY || (e.clientY - tlCanvas.getBoundingClientRect().top);
       const hit = tlHitTest(px, py);
       tlCanvas.style.cursor = hit ? (hit.mode === 'trim-in' || hit.mode === 'trim-out' ? 'ew-resize' : 'grab') : 'default';
+      // Cut info popup on hover
+      const infoPopup = document.getElementById('cut-info-popup');
+      const infoContent = document.getElementById('cut-info-content');
+      if (hit && summary?.cuts?.[hit.cutIndex]) {
+        const c = summary.cuts[hit.cutIndex];
+        const src = summary.sources?.find(s => s.id === c.src)?.path || c.src || '(no source)';
+        const srcName = src.split('/').pop();
+        const dur = (((c.out || 0) - (c.in || 0)) / (c.speed || 1)).toFixed(2);
+        const fmt = (sec) => { const m = Math.floor(sec / 60); return `${m}:${String(Math.floor(sec % 60)).padStart(2, '0')}.${String(Math.floor((sec % 1) * 100)).padStart(2, '0')}`; };
+        infoContent.innerHTML = `<div><b>#${hit.cutIndex + 1}</b> ${srcName}</div><div>in: ${fmt(c.in || 0)}  out: ${fmt(c.out || 0)}  dur: ${dur}s</div>${c.at !== undefined ? `<div>at: ${fmt(c.at)}</div>` : ''}`;
+        const wrapRect = tlCanvasWrap.getBoundingClientRect();
+        infoPopup.style.position = 'fixed';
+        infoPopup.style.left = Math.min(e.clientX + 12, window.innerWidth - 292) + 'px';
+        infoPopup.style.top = Math.max(8, e.clientY - infoPopup.offsetHeight - 8) + 'px';
+        infoPopup.hidden = false;
+      } else if (infoPopup) {
+        infoPopup.hidden = true;
+      }
       return;
     }
     const px = tlTimelineX(e);
@@ -2267,7 +2345,23 @@ function setupTimeline() {
       cut.out = newOut;
     } else if (tlDrag.mode === 'move') {
       const newAt = Math.max(0, +(tlDrag.startAt + deltaFrames).toFixed(2));
-      cut.at = newAt;
+      const snap = tlSnapTime(newAt, tlDrag.cutIndex);
+      cut.at = snap !== null ? snap : newAt;
+    }
+    // Snap right edge for trim
+    if (tlDrag.mode === 'trim-out' || tlDrag.mode === 'trim-in') {
+      const atPos = tlDrag.startAt !== null ? tlDrag.startAt : tlDrag.cursorStart;
+      const speed = cut.speed || 1;
+      const rightEdge = atPos + ((cut.out || 0) - (cut.in || 0)) / speed;
+      const snap = tlSnapTime(rightEdge, tlDrag.cutIndex);
+      if (snap !== null) {
+        const newDur = snap - atPos;
+        if (tlDrag.mode === 'trim-out') {
+          cut.out = Math.max(cut.in + 1 / fps, +(cut.in + newDur * speed).toFixed(3));
+        } else {
+          cut.in = Math.max(0, Math.min(cut.out - 1 / fps, +(cut.out - newDur * speed).toFixed(3)));
+        }
+      }
     }
     // Re-render timeline with new cuts
     const oldCuts = summary.cuts;
@@ -2276,6 +2370,11 @@ function setupTimeline() {
     summary.cuts = oldCuts;
     tlDrag.saved = false;
     e.preventDefault();
+  });
+
+  tlCanvas.addEventListener('pointerleave', () => {
+    const p = document.getElementById('cut-info-popup');
+    if (p) p.hidden = true;
   });
 
   tlCanvas.addEventListener('pointerup', async (e) => {
@@ -2439,6 +2538,15 @@ function renderTimeline() {
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
       ctx.fillText(`#${seg.index + 1}`, sx + sw / 2, y + TL_TRACK_HEIGHT / 2);
+    }
+    // Source time label (in/out)
+    if (sw > 80) {
+      ctx.fillStyle = 'rgba(255,255,255,0.4)';
+      ctx.font = '8px system-ui, sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'bottom';
+      const fmt = (sec) => { const m = Math.floor(sec / 60); return `${m}:${String(Math.floor(sec % 60)).padStart(2, '0')}.${String(Math.floor((sec % 1) * 100)).padStart(2, '0')}`; };
+      ctx.fillText(`${fmt(seg.inSec)} → ${fmt(seg.outSec)}`, sx + sw / 2, y + 1);
     }
     cursor += seg.durationSec;
   }

--- a/packages/preview-server/public/app.js
+++ b/packages/preview-server/public/app.js
@@ -2027,6 +2027,487 @@ function logReviewEvent(type, extra) {
   reviewEvents.push({ recT: +recT.toFixed(3), type, timelineT: +outputTime.toFixed(3), playing: isPlaying, ...extra });
 }
 
+// --- Asset Browser ---
+const assetList = document.getElementById('asset-list');
+const assetSearch = document.getElementById('asset-search');
+const assetTabs = document.querySelectorAll('.asset-tab');
+const ASSET_ICONS = { video: '🎬', audio: '🎵', image: '🖼️' };
+
+let allAssets = [];
+let assetFilterCat = 'all';
+let assetFilterText = '';
+
+function formatSize(bytes) {
+  if (bytes < 1024) return bytes + 'B';
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + 'KB';
+  return (bytes / (1024 * 1024)).toFixed(1) + 'MB';
+}
+
+function renderAssets() {
+  const filtered = allAssets.filter(a => {
+    if (assetFilterCat !== 'all' && a.category !== assetFilterCat) return false;
+    if (assetFilterText && !a.name.toLowerCase().includes(assetFilterText)) return false;
+    return true;
+  });
+  if (!filtered.length) {
+    assetList.innerHTML = '<div class="asset-empty">素材がありません<br>ファイルをドロップして追加</div>';
+    return;
+  }
+  assetList.innerHTML = filtered.map(a => `
+    <div class="asset-item" draggable="true" data-path="${a.path}" data-category="${a.category}">
+      <div class="asset-icon ${a.category}">${ASSET_ICONS[a.category] || '📄'}</div>
+      <div class="asset-info">
+        <div class="asset-name">${esc(a.name)}</div>
+        <div class="asset-meta">${a.category} · ${formatSize(a.size)}</div>
+      </div>
+    </div>
+  `).join('');
+  // Drag start — store asset path for timeline drop
+  assetList.querySelectorAll('.asset-item').forEach(el => {
+    el.addEventListener('dragstart', (e) => {
+      e.dataTransfer.setData('text/plain', el.dataset.path);
+      e.dataTransfer.effectAllowed = 'copy';
+      el.classList.add('is-active');
+    });
+    el.addEventListener('dragend', () => el.classList.remove('is-active'));
+  });
+}
+
+function setupAssetBrowser() {
+  // Tabs
+  for (const tab of assetTabs) {
+    tab.addEventListener('click', () => {
+      assetTabs.forEach(t => t.classList.remove('active'));
+      tab.classList.add('active');
+      assetFilterCat = tab.dataset.cat;
+      renderAssets();
+    });
+  }
+  // Search
+  assetSearch.addEventListener('input', () => {
+    assetFilterText = assetSearch.value.toLowerCase();
+    renderAssets();
+  });
+  // Click to show in editor (add to sources or navigate)
+  assetList.addEventListener('click', (e) => {
+    const item = e.target.closest('.asset-item');
+    if (!item) return;
+    showMessage(null);
+  });
+  // Drag-and-drop upload
+  const assetPane = document.getElementById('asset-pane');
+  let dropOverlay = null;
+  function showDropOverlay(show) {
+    if (show) {
+      if (!dropOverlay) {
+        dropOverlay = document.createElement('div');
+        dropOverlay.style.cssText = 'position:absolute;inset:0;z-index:100;background:rgba(77,163,255,0.12);border:2px dashed #4da3ff;display:grid;place-items:center;font-size:14px;color:#4da3ff;font-weight:600;pointer-events:none;border-radius:4px;';
+        dropOverlay.textContent = 'ドロップして素材を追加';
+        assetPane.style.position = 'relative';
+      }
+      assetPane.appendChild(dropOverlay);
+    } else {
+      if (dropOverlay && dropOverlay.parentNode) dropOverlay.remove();
+    }
+  }
+  assetPane.addEventListener('dragenter', (e) => { e.preventDefault(); showDropOverlay(true); });
+  assetPane.addEventListener('dragover', (e) => { e.preventDefault(); });
+  assetPane.addEventListener('dragleave', (e) => {
+    if (!assetPane.contains(e.relatedTarget)) showDropOverlay(false);
+  });
+  assetPane.addEventListener('drop', async (e) => {
+    e.preventDefault();
+    showDropOverlay(false);
+    const files = Array.from(e.dataTransfer.files).filter(f => {
+      const ext = '.' + f.name.split('.').pop().toLowerCase();
+      return /\.(mp4|webm|mov|avi|mkv|m4v|mp3|wav|ogg|aac|flac|m4a|png|jpg|jpeg|gif|webp)$/i.test(ext);
+    });
+    if (!files.length) { showMessage('対応形式: mp4/webm/mov/avi/mkv/mp3/wav/ogg/png/jpg など'); return; }
+    showMessage(`${files.length}個のファイルをアップロード中...`);
+    let ok = 0, err = 0;
+    for (const file of files) {
+      try {
+        const res = await fetch('/api/assets/upload', {
+          method: 'POST',
+          headers: { 'X-File-Name': encodeURIComponent(file.name) },
+          body: file,
+        });
+        if (res.ok) ok++; else err++;
+      } catch { err++; }
+    }
+    if (err === 0) showMessage(`${ok}個のファイルを追加しました`);
+    else showMessage(`${ok}個追加、${err}個失敗`);
+    await loadAssets();
+  });
+}
+
+async function loadAssets() {
+  try {
+    const res = await fetch('/api/project-files');
+    if (!res.ok) return;
+    allAssets = await res.json();
+    renderAssets();
+  } catch {}
+}
+
+// --- Timeline Editor ---
+const tlCanvas = document.getElementById('timeline-canvas');
+const tlRulerCanvas = document.getElementById('tl-ruler-canvas');
+const tlPlayhead = document.getElementById('tl-playhead');
+const tlCanvasWrap = document.getElementById('tl-canvas-wrap');
+const tlZoomIn = document.getElementById('tl-zoom-in');
+const tlZoomOut = document.getElementById('tl-zoom-out');
+const tlZoomLabel = document.getElementById('tl-zoom-label');
+const tlFitBtn = document.getElementById('tl-fit-btn');
+
+let tlZoom = 1;
+let tlScrollLeft = 0;
+let tlDrag = null;
+const TL_TRACK_HEIGHT = 28;
+const TL_MIN_ZOOM = 5;
+const TL_MAX_ZOOM = 500;
+const TL_HANDLE_PX = 8;
+const TL_CUT_COLORS = ['#4da3ff', '#ff6b6b', '#51cf66', '#ffd43b', '#cc5de8', '#20c997', '#ff922b', '#748ffc'];
+
+function computeNaturalZoom() {
+  if (totalDuration <= 0) return 100;
+  const w = tlCanvasWrap.clientWidth - 16;
+  return Math.max(TL_MIN_ZOOM, Math.min(TL_MAX_ZOOM, w / totalDuration));
+}
+
+function tlTimelineX(e) {
+  const rect = tlCanvas.getBoundingClientRect();
+  return e.clientX - rect.left + tlCanvasWrap.scrollLeft;
+}
+
+function tlTimeFromX(px) {
+  return Math.max(0, Math.min(totalDuration, px / tlZoom));
+}
+
+function tlHitTest(px, py) {
+  if (py < 0 || py > TL_TRACK_HEIGHT * 2) return null;
+  const track = py < TL_TRACK_HEIGHT ? 0 : 1;
+  let cursor = 0;
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    if (seg.isGap) { cursor += seg.durationSec; continue; }
+    if (seg.track !== track) { cursor += seg.durationSec; continue; }
+    const sx = cursor * tlZoom;
+    const sw = seg.durationSec * tlZoom;
+    if (px >= sx && px < sx + sw) {
+      const distL = px - sx;
+      const distR = (sx + sw) - px;
+      let mode;
+      if (distL < TL_HANDLE_PX && sw > TL_HANDLE_PX * 2) mode = 'trim-in';
+      else if (distR < TL_HANDLE_PX && sw > TL_HANDLE_PX * 2) mode = 'trim-out';
+      else mode = 'move';
+      return { segIndex: i, cutIndex: seg.index, mode, cursor };
+    }
+    cursor += seg.durationSec;
+  }
+  return null;
+}
+
+function setupTimeline() {
+  tlZoomIn.addEventListener('click', () => { tlZoom = Math.min(TL_MAX_ZOOM, tlZoom * 1.5); renderTimeline(); });
+  tlZoomOut.addEventListener('click', () => { tlZoom = Math.max(TL_MIN_ZOOM, tlZoom / 1.5); renderTimeline(); });
+  tlFitBtn.addEventListener('click', () => { tlZoom = computeNaturalZoom(); renderTimeline(); });
+  tlCanvasWrap.addEventListener('scroll', () => { tlScrollLeft = tlCanvasWrap.scrollLeft; updateTimelinePlayhead(); });
+
+  // Pointer interaction: trim / move / seek
+  tlCanvas.addEventListener('pointerdown', (e) => {
+    if (e.button !== 0) return;
+    const px = tlTimelineX(e);
+    const py = e.clientY - tlCanvas.getBoundingClientRect().top;
+    const hit = tlHitTest(px, py);
+    if (!hit || hit.mode === 'move' && hit.segIndex < 0) {
+      // seek
+      const t = tlTimeFromX(px);
+      const w = isPlaying; if (w) pause();
+      seekTo(t);
+      return;
+    }
+    const seg = segments[hit.segIndex];
+    const cut = summary?.cuts?.[hit.cutIndex];
+    if (!cut) return;
+    tlDrag = {
+      mode: hit.mode, segIndex: hit.segIndex, cutIndex: hit.cutIndex,
+      startPx: px,
+      startIn: cut.in, startOut: cut.out,
+      startSegIn: seg.inSec, startSegOut: seg.outSec,
+      startAt: cut.at !== undefined ? cut.at : null,
+      saved: false, moved: false,
+      cursorStart: hit.cursor,
+    };
+    tlCanvas.setPointerCapture(e.pointerId);
+    e.preventDefault();
+  });
+
+  tlCanvas.addEventListener('pointermove', (e) => {
+    if (!tlDrag) {
+      // Cursor change on hover
+      const px = tlTimelineX(e);
+      const py = e.offsetY || (e.clientY - tlCanvas.getBoundingClientRect().top);
+      const hit = tlHitTest(px, py);
+      tlCanvas.style.cursor = hit ? (hit.mode === 'trim-in' || hit.mode === 'trim-out' ? 'ew-resize' : 'grab') : 'default';
+      return;
+    }
+    const px = tlTimelineX(e);
+    const deltaSec = (px - tlDrag.startPx) / tlZoom;
+    const deltaFrames = Math.round(deltaSec * fps) / fps;
+    const newEdit = JSON.parse(JSON.stringify(summary));
+    const cut = newEdit.cuts[tlDrag.cutIndex];
+    if (!cut) return;
+    if (Math.abs(px - tlDrag.startPx) > 3) tlDrag.moved = true;
+    if (tlDrag.mode === 'trim-in') {
+      const newIn = Math.max(0, +(tlDrag.startIn + deltaFrames).toFixed(2));
+      if (newIn < cut.out - (1 / fps)) cut.in = newIn;
+    } else if (tlDrag.mode === 'trim-out') {
+      const newOut = Math.max(cut.in + (1 / fps), +(tlDrag.startOut + deltaFrames).toFixed(2));
+      cut.out = newOut;
+    } else if (tlDrag.mode === 'move') {
+      const newAt = Math.max(0, +(tlDrag.startAt + deltaFrames).toFixed(2));
+      cut.at = newAt;
+    }
+    // Re-render timeline with new cuts
+    const oldCuts = summary.cuts;
+    summary.cuts = newEdit.cuts;
+    buildSegments();
+    summary.cuts = oldCuts;
+    tlDrag.saved = false;
+    e.preventDefault();
+  });
+
+  tlCanvas.addEventListener('pointerup', async (e) => {
+    if (!tlDrag) return;
+    tlCanvas.releasePointerCapture(e.pointerId);
+    if (tlDrag.saved) { tlDrag = null; return; }
+    if (!tlDrag.moved) {
+      // No drag — just seek
+      const t = tlTimeFromX(tlTimelineX(e));
+      const w = isPlaying; if (w) pause();
+      seekTo(t);
+      tlDrag = null;
+      return;
+    }
+    // Save to server
+    const newEdit = JSON.parse(JSON.stringify(summary));
+    const cut = newEdit.cuts[tlDrag.cutIndex];
+    if (!cut) { tlDrag = null; return; }
+    if (tlDrag.mode === 'trim-in') {
+      const deltaSec = (tlTimelineX(e) - tlDrag.startPx) / tlZoom;
+      cut.in = Math.max(0, +(tlDrag.startIn + deltaSec).toFixed(2));
+    } else if (tlDrag.mode === 'trim-out') {
+      const deltaSec = (tlTimelineX(e) - tlDrag.startPx) / tlZoom;
+      cut.out = Math.max(cut.in + (1 / fps), +(tlDrag.startOut + deltaSec).toFixed(2));
+    } else if (tlDrag.mode === 'move') {
+      const deltaSec = (tlTimelineX(e) - tlDrag.startPx) / tlZoom;
+      cut.at = Math.max(0, +(tlDrag.startAt + deltaSec).toFixed(2));
+    }
+    try {
+      const res = await fetch('/api/edit.json', {
+        method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(newEdit)
+      });
+      if (res.ok) {
+        await reloadSummary();
+        buildSegments();
+        seekTo(outputTime);
+        tlDrag.saved = true;
+      } else {
+        showMessage(await editSaveErrorMessage(res));
+        buildSegments();
+        renderTimeline();
+      }
+    } catch (err) { showMessage(err?.message || String(err)); buildSegments(); renderTimeline(); }
+    tlDrag = null;
+  });
+
+  tlCanvas.addEventListener('pointercancel', () => {
+    if (tlDrag) { tlDrag = null; buildSegments(); renderTimeline(); }
+  });
+
+  // Mouse wheel to zoom
+  tlCanvasWrap.addEventListener('wheel', (e) => {
+    if (!e.ctrlKey && !e.metaKey) return;
+    e.preventDefault();
+    const rect = tlCanvasWrap.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const tUnder = (mx + tlCanvasWrap.scrollLeft) / tlZoom;
+    const factor = e.deltaY > 0 ? 1 / 1.15 : 1.15;
+    tlZoom = Math.max(TL_MIN_ZOOM, Math.min(TL_MAX_ZOOM, tlZoom * factor));
+    renderTimeline();
+    tlCanvasWrap.scrollLeft = tUnder * tlZoom - mx;
+  }, { passive: false });
+
+  // Drop asset on timeline
+  let dropIndicator = null;
+  tlCanvas.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+    if (!dropIndicator) {
+      dropIndicator = document.createElement('div');
+      dropIndicator.style.cssText = 'position:absolute;top:0;bottom:0;width:2px;background:#4da3ff;z-index:6;pointer-events:none;';
+      (tlCanvasWrap.querySelector('div') || tlCanvasWrap).appendChild(dropIndicator);
+    }
+    dropIndicator.style.left = (tlTimelineX(e) - tlCanvasWrap.scrollLeft) + 'px';
+  });
+  tlCanvasWrap.addEventListener('dragleave', (e) => {
+    if (!tlCanvasWrap.contains(e.relatedTarget)) { dropIndicator?.remove(); dropIndicator = null; }
+  });
+  tlCanvas.addEventListener('drop', async (e) => {
+    e.preventDefault();
+    dropIndicator?.remove(); dropIndicator = null;
+    const assetPath = e.dataTransfer.getData('text/plain');
+    if (!assetPath || !summary?.cuts) return;
+    const t = tlTimeFromX(tlTimelineX(e));
+    const newEdit = JSON.parse(JSON.stringify(summary));
+    if (!Array.isArray(newEdit.sources)) newEdit.sources = [];
+    const srcId = 'src-' + Date.now();
+    newEdit.sources.push({ id: srcId, path: assetPath });
+    newEdit.cuts = [...newEdit.cuts, { in: 0, out: 2, src: srcId, at: +t.toFixed(2) }];
+    try {
+      const res = await fetch('/api/edit.json', {
+        method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(newEdit)
+      });
+      if (res.ok) { await reloadSummary(); buildSegments(); seekTo(outputTime); }
+      else showMessage(await editSaveErrorMessage(res));
+    } catch (err) { showMessage(err?.message || String(err)); }
+  });
+}
+
+function renderTimeline() {
+  const wrapW = tlCanvasWrap.clientWidth;
+  const totalPx = Math.max(wrapW, totalDuration * tlZoom);
+  const h = TL_TRACK_HEIGHT * 2;
+  tlCanvas.width = Math.ceil(totalPx) * devicePixelRatio;
+  tlCanvas.height = h * devicePixelRatio;
+  tlCanvas.style.width = Math.ceil(totalPx) + 'px';
+  tlCanvas.style.height = h + 'px';
+  const ctx = tlCanvas.getContext('2d');
+  ctx.scale(devicePixelRatio, devicePixelRatio);
+  ctx.fillStyle = '#161616';
+  ctx.fillRect(0, 0, totalPx, h);
+  // Grid
+  ctx.strokeStyle = '#222';
+  ctx.lineWidth = 1;
+  const step = tlZoom >= 100 ? 1 : tlZoom >= 40 ? 5 : tlZoom >= 15 ? 10 : 30;
+  for (let t = step; t <= totalDuration; t += step) {
+    const x = t * tlZoom;
+    ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, h); ctx.stroke();
+  }
+  // Draw cuts with handles
+  let cursor = 0;
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    if (seg.isGap) { cursor += seg.durationSec; continue; }
+    const sx = cursor * tlZoom;
+    const sw = seg.durationSec * tlZoom;
+    const color = TL_CUT_COLORS[seg.index % TL_CUT_COLORS.length];
+    const y = seg.track === 0 ? 0 : TL_TRACK_HEIGHT;
+    const segH = TL_TRACK_HEIGHT - 4;
+    // Main body
+    const grad = ctx.createLinearGradient(sx, y, sx, y + TL_TRACK_HEIGHT);
+    grad.addColorStop(0, color);
+    grad.addColorStop(0.5, color);
+    grad.addColorStop(1, '#000');
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    const r = 3;
+    const rx = sx, ry = y + 2, rw = Math.max(2, sw), rh = segH;
+    ctx.moveTo(rx + r, ry); ctx.lineTo(rx + rw - r, ry); ctx.quadraticCurveTo(rx + rw, ry, rx + rw, ry + r);
+    ctx.lineTo(rx + rw, ry + rh - r); ctx.quadraticCurveTo(rx + rw, ry + rh, rx + rw - r, ry + rh);
+    ctx.lineTo(rx + r, ry + rh); ctx.quadraticCurveTo(rx, ry + rh, rx, ry + rh - r);
+    ctx.lineTo(rx, ry + r); ctx.quadraticCurveTo(rx, ry, rx + r, ry);
+    ctx.fill();
+    // Handle zones
+    if (sw > TL_HANDLE_PX * 3) {
+      ctx.fillStyle = 'rgba(0,0,0,0.25)';
+      ctx.fillRect(sx, y + 2, TL_HANDLE_PX, segH);
+      ctx.fillRect(sx + sw - TL_HANDLE_PX, y + 2, TL_HANDLE_PX, segH);
+      // Handle grips
+      ctx.fillStyle = 'rgba(255,255,255,0.3)';
+      for (let g = 0; g < 3; g++) {
+        const gh = y + 2 + 5 + g * 6;
+        ctx.fillRect(sx + 2, gh, 4, 2);
+        ctx.fillRect(sx + sw - 6, gh, 4, 2);
+      }
+    }
+    // Label
+    if (sw > 30) {
+      ctx.fillStyle = '#fff';
+      ctx.font = '10px system-ui, sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(`#${seg.index + 1}`, sx + sw / 2, y + TL_TRACK_HEIGHT / 2);
+    }
+    cursor += seg.durationSec;
+  }
+  // Track separator
+  ctx.strokeStyle = '#303030';
+  ctx.beginPath(); ctx.moveTo(0, TL_TRACK_HEIGHT); ctx.lineTo(totalPx, TL_TRACK_HEIGHT); ctx.stroke();
+  // Ruler
+  tlRulerCanvas.width = Math.ceil(totalPx) * devicePixelRatio;
+  tlRulerCanvas.height = 22 * devicePixelRatio;
+  tlRulerCanvas.style.width = Math.ceil(totalPx) + 'px';
+  const rctx = tlRulerCanvas.getContext('2d');
+  rctx.scale(devicePixelRatio, devicePixelRatio);
+  rctx.fillStyle = '#141414';
+  rctx.fillRect(0, 0, totalPx, 22);
+  rctx.strokeStyle = '#333';
+  rctx.lineWidth = 1;
+  rctx.fillStyle = '#666';
+  rctx.font = '9px system-ui, sans-serif';
+  rctx.textAlign = 'center';
+  rctx.textBaseline = 'bottom';
+  for (let t = 0; t <= totalDuration; t += step) {
+    const x = t * tlZoom;
+    const rh = t % (step * 5) === 0 ? 14 : 8;
+    rctx.beginPath(); rctx.moveTo(x, 22); rctx.lineTo(x, 22 - rh); rctx.stroke();
+    if (t % (step * 5) === 0 || step <= 1) {
+      const m = Math.floor(t / 60);
+      const s = Math.floor(t % 60);
+      rctx.fillText(`${m}:${String(s).padStart(2, '0')}`, x, 20);
+    }
+  }
+  tlZoomLabel.textContent = Math.round(tlZoom) + 'px/s';
+  // drag preview overlay
+  if (tlDrag) {
+    ctx.fillStyle = 'rgba(255,255,255,0.08)';
+    const seg = segments[tlDrag.segIndex];
+    if (seg && !seg.isGap) {
+      let dc = 0;
+      for (let j = 0; j < tlDrag.segIndex; j++) { if (!segments[j].isGap) dc += segments[j].durationSec; }
+      const dx = (tlDrag.cursorStart + (segments[tlDrag.segIndex]?.durationSec || 0) / 2) * tlZoom - 20;
+      ctx.fillRect(dx, 0, 40, h);
+    }
+  }
+  updateTimelinePlayhead();
+}
+
+function updateTimelinePlayhead() {
+  if (totalDuration <= 0) { tlPlayhead.style.display = 'none'; return; }
+  tlPlayhead.style.display = 'block';
+  const x = outputTime * tlZoom - tlCanvasWrap.scrollLeft;
+  tlPlayhead.style.left = Math.max(0, x) + 'px';
+  tlPlayhead.style.height = (TL_TRACK_HEIGHT * 2) + 'px';
+}
+
+// Extend existing functions
+const origSeekTo = seekTo;
+seekTo = function(t) {
+  origSeekTo(t);
+  updateTimelinePlayhead();
+};
+
+const origBuildSegments = buildSegments;
+buildSegments = function() {
+  origBuildSegments();
+  if (totalDuration > 0) {
+    tlZoom = computeNaturalZoom();
+    renderTimeline();
+  }
+};
+
 // --- Output preview ---
 const outputBtn = document.getElementById('output-preview-btn');
 if (isOutputMode) {
@@ -2042,3 +2523,6 @@ if (isOutputMode) {
 
 init();
 connectWs();
+setupAssetBrowser();
+setupTimeline();
+loadAssets();

--- a/packages/preview-server/public/app.js
+++ b/packages/preview-server/public/app.js
@@ -2634,3 +2634,11 @@ connectWs();
 setupAssetBrowser();
 setupTimeline();
 loadAssets();
+
+// Expose internals for tests
+window.__test = {
+  get summary() { return summary; },
+  get segments() { return segments; },
+  get outputTime() { return outputTime; },
+  seekTo, getActiveSegment, tlSplitCut, tlDeleteCut,
+};

--- a/packages/preview-server/public/app.js
+++ b/packages/preview-server/public/app.js
@@ -32,22 +32,12 @@ const zoomPopup = document.getElementById('zoom-popup');
 const zoomSlider = document.getElementById('zoom-slider');
 const zoomValue = document.getElementById('zoom-value');
 const fullscreenToggle = document.getElementById('fullscreen-toggle');
-const waveformToggle = document.getElementById('waveform-toggle');
-const waveformRow = document.querySelector('.transport-waveform');
-const waveformCanvas = document.getElementById('waveform-canvas');
-const waveformPlayhead = document.querySelector('.transport-waveform-playhead');
-const trackCanvases = {
-  bgm: document.querySelector('.waveform-track-canvas[data-track="bgm"]'),
-  narration: document.querySelector('.waveform-track-canvas[data-track="narration"]'),
-  sfx: document.querySelector('.waveform-track-canvas[data-track="sfx"]'),
-};
 const stage = document.getElementById('overlay-stage');
 const captionPlate = document.getElementById('caption-plate');
 const transitionPlate = document.getElementById('transition-plate');
 const wrapper = document.getElementById('preview-wrapper');
 const zoomLayer = document.getElementById('zoom-layer');
-const previewMessage = document.getElementById('preview-message');
-const previewMessageText = document.getElementById('preview-message-text');
+const toast = document.getElementById('toast');
 const editToggle = document.getElementById('edit-toggle');
 const selectionLabel = document.getElementById('selection-label');
 const transformPopup = document.getElementById('transform-popup');
@@ -70,8 +60,6 @@ const reviewTimer = document.getElementById('review-timer');
 const ZONE_ROW_RANGES = { top: [0, 1 / 3], middle: [1 / 3, 2 / 3], bottom: [2 / 3, 1] };
 const ZONE_COL_RANGES = { left: [0, 1 / 3], center: [1 / 3, 2 / 3], right: [2 / 3, 1] };
 const CAPTION_ZONE_LIST = ['bottom', 'bottom-left', 'bottom-right', 'center', 'left', 'right', 'top', 'top-left', 'top-right'];
-const TRACK_COLORS = { bgm: '#4da3ff', narration: '#ffd94a', sfx: '#ff798c' };
-
 const playIcon = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>';
 const pauseIcon = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 5h4v14H7zm6 0h4v14h-4z"/></svg>';
 const fullscreenIcon = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9V4h5v2H6v3zm11-5h5v5h-2V6h-3zm3 11h2v5h-5v-2h3zM9 18v2H4v-5h2v3z"/></svg>';
@@ -100,20 +88,106 @@ let bgmNode = null;
 let sfxNodes = [];
 let narrationNodes = [];
 
-let waveformPeaks = null;
-let waveformDuration = 0;
 let reviewSession = null;
 let reviewRecorder = null;
 let reviewStream = null;
 let reviewRecStart = 0;
 let reviewTimerRAF = 0;
 let reviewEvents = [];
-let trackWaveforms = { bgm: null, narration: null, sfx: null };
 let captionsData = null;
 let captionStylesInjected = false;
 
 // B-roll layer videos
 let layerVideos = [];
+
+// Segment video elements — one per non-gap segment, preloaded to prevent src-change flash
+let segmentVideos = [];
+let activeVideoIndex = -1;
+
+// Asset preview mode: set when an asset is being inspected in the preview window
+let assetPreview = null;
+
+function ensureSegmentVideo(segIndex) {
+  if (segmentVideos[segIndex]) return segmentVideos[segIndex];
+  const seg = segments[segIndex];
+  if (!seg || seg.isGap || seg.index < 0) return null;
+  const src = getVideoSource(seg.index);
+  if (!src) return null;
+  let v;
+  if (segIndex === 0) {
+    v = video;
+    v.muted = true;
+    if (v.src !== src) v.src = src;
+  } else {
+    v = document.createElement('video');
+    v.preload = 'auto';
+    v.muted = true;
+    v.playsInline = true;
+    v.dataset.src = src;
+    v.style.cssText = 'position:absolute;width:100%;height:100%;object-fit:contain;display:none';
+    zoomLayer.insertBefore(v, stage);
+    v.src = src;
+  }
+  segmentVideos[segIndex] = v;
+  return v;
+}
+
+function getActiveVideo() {
+  if (activeVideoIndex >= 0 && segmentVideos[activeVideoIndex]) return segmentVideos[activeVideoIndex];
+  return video;
+}
+
+function activateSegmentVideo(segIndex, targetTime) {
+  if (segIndex === activeVideoIndex) {
+    if (targetTime !== undefined) getActiveVideo().currentTime = targetTime;
+    return;
+  }
+  ensureSegmentVideo(segIndex);
+  const cur = getActiveVideo();
+  if (cur !== video) cur.style.display = 'none';
+  activeVideoIndex = segIndex;
+  const next = getActiveVideo();
+  if (next) {
+    if (next !== video) next.style.display = 'block';
+    if (targetTime !== undefined) next.currentTime = targetTime;
+  }
+}
+
+function setupSegmentVideos() {
+  for (let i = segments.length; i < segmentVideos.length; i++) {
+    if (segmentVideos[i] && segmentVideos[i] !== video && segmentVideos[i].parentNode) segmentVideos[i].remove();
+  }
+  segmentVideos.length = segments.length;
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    if (seg.isGap || seg.index < 0) {
+      if (segmentVideos[i] && segmentVideos[i] !== video) { segmentVideos[i].remove(); }
+      segmentVideos[i] = null;
+      continue;
+    }
+    const src = getVideoSource(seg.index);
+    if (!src) {
+      if (segmentVideos[i] && segmentVideos[i] !== video) segmentVideos[i].remove();
+      segmentVideos[i] = null;
+      continue;
+    }
+    if (i === 0) {
+      if (segmentVideos[0] !== video) { segmentVideos[0] = video; video.src = src; }
+      video.currentTime = 0;
+      continue;
+    }
+    if (segmentVideos[i] && segmentVideos[i].dataset && segmentVideos[i].dataset.src === src) continue;
+    if (segmentVideos[i] && segmentVideos[i] !== video) segmentVideos[i].remove();
+    const v = document.createElement('video');
+    v.preload = 'auto'; v.muted = true; v.playsInline = true;
+    v.dataset.src = src;
+    v.style.cssText = 'position:absolute;width:100%;height:100%;object-fit:contain;display:none';
+    zoomLayer.insertBefore(v, stage);
+    v.src = src;
+    segmentVideos[i] = v;
+  }
+  activeVideoIndex = -1;
+}
 
 // Pen annotation
 let penPoints = [];
@@ -179,21 +253,25 @@ function normalizeTracks(edit) {
   }
   if (edit.audio) {
     if (edit.audio.bgm) {
-      tracks.push({
-        id: 'trk-audio-bgm',
-        type: 'audio',
-        label: 'BGM',
-        clips: [{
-          id: 'clip-bgm',
-          src: edit.audio.bgm.path || edit.audio.bgm.src,
-          at: edit.audio.bgm.t ?? 0,
-          gainDb: edit.audio.bgm.gainDb ?? edit.audio.bgm.gain_db ?? 0,
-          ducking: edit.audio.bgm.ducking ?? false,
-          loop: edit.audio.bgm.loop !== false,
-          fadeIn: edit.audio.bgm.fadeIn,
-          fadeOut: edit.audio.bgm.fadeOut,
-        }],
-      });
+      const bgmList = Array.isArray(edit.audio.bgm) ? edit.audio.bgm : [edit.audio.bgm];
+      for (const bgm of bgmList) {
+        if (!bgm) continue;
+        tracks.push({
+          id: bgmList.length > 1 ? `trk-audio-bgm-${bgmList.indexOf(bgm)}` : 'trk-audio-bgm',
+          type: 'audio',
+          label: 'MUSIC',
+          clips: [{
+            id: bgm.id || 'clip-bgm',
+            src: bgm.path || bgm.src,
+            at: bgm.t ?? bgm.offset ?? 0,
+            gainDb: bgm.gainDb ?? bgm.gain_db ?? 0,
+            ducking: bgm.ducking ?? false,
+            loop: bgm.loop !== false,
+            fadeIn: bgm.fadeIn,
+            fadeOut: bgm.fadeOut,
+          }],
+        });
+      }
     }
     if (Array.isArray(edit.audio.narration)) {
       for (const n of edit.audio.narration) {
@@ -322,12 +400,12 @@ async function init() {
     fps = timelineData.fps || 30;
 
     buildSegments();
-    if (summary?.cuts?.length > 0) video.src = getVideoSource(0);
+    setupSegmentVideos();
+    seekTo(0);
     setupLayers();
     setupPenCanvas();
     initPenSprites();
     setupAudioGraph();
-    setupWaveform();
     scheduleTransitions();
     setupMinimap();
 
@@ -341,12 +419,14 @@ async function init() {
 
     // Restore settings
     if (savedSettings.zoom && savedSettings.zoom >= ZOOM_MIN && savedSettings.zoom <= ZOOM_MAX) {
-      zoom = savedSettings.zoom; updateZoom();
+      zoom = savedSettings.zoom;
     }
-    if (savedSettings.waveformVisible) {
-      waveformVisible = true; waveformRow.hidden = false;
-      waveformToggle.setAttribute('aria-pressed', 'true');
-      setTimeout(setupWaveform, 100);
+    updateZoom();
+    if (savedSettings.paneLeftWidth) {
+      document.documentElement.style.setProperty('--pane-left-width', savedSettings.paneLeftWidth + 'px');
+    }
+    if (savedSettings.paneBottomHeight) {
+      document.documentElement.style.setProperty('--pane-bottom-height', savedSettings.paneBottomHeight + 'px');
     }
 
     showMessage(null);
@@ -646,7 +726,7 @@ function penEnable(enabled) {
 // --- Minimap ---
 function setupMinimap() {
   if (!summary?.cuts?.length) return;
-  minimapVideo.src = video.src;
+  minimapVideo.src = getVideoSource(0);
 }
 function updateMinimap() {
   if (zoom <= 1) { minimap.hidden = true; return; }
@@ -767,128 +847,6 @@ function recreateBgmSource(t) {
   if (isPlaying) { src.start(0, Math.max(0, t)); src._started = true; }
   bgmNode._source = src;
 }
-// --- Waveform ---
-async function computePeaks(url, numPeaks) {
-  try {
-    const r = await fetch(url);
-    if (!r.ok) return null;
-    const ab = await r.arrayBuffer();
-    const buf = await audioCtx.decodeAudioData(ab.slice(0));
-    const ch = buf.getChannelData(0);
-    const pn = Math.min(numPeaks || 200, ch.length);
-    const spp = Math.max(1, Math.floor(ch.length / pn));
-    const peaks = [];
-    for (let i = 0; i < pn; i++) {
-      let max = 0;
-      for (let j = 0; j < spp && i * spp + j < ch.length; j++) max = Math.max(max, Math.abs(ch[i * spp + j]));
-      peaks.push(max);
-    }
-    return { peaks, duration: buf.duration };
-  } catch { return null; }
-}
-async function setupWaveform() {
-  waveformCanvas.width = waveformCanvas.clientWidth * devicePixelRatio;
-  waveformCanvas.height = waveformCanvas.clientHeight * devicePixelRatio;
-  if (!timelineData.clips.length || !audioCtx) return;
-  const main = await computePeaks(timelineData.clips[0].src, 400);
-  if (main) { waveformPeaks = main.peaks; waveformDuration = main.duration; }
-  trackWaveforms = { bgm: null, narration: null, sfx: null };
-  const audio = summary?.audio;
-  const bgmUrl = audio?.bgm?.src || resolveMediaUrl(audio?.bgm?.path);
-  if (bgmUrl) {
-    const t = await computePeaks(bgmUrl, 200);
-    if (t) { t.color = TRACK_COLORS.bgm; t.t = audio.bgm.t ?? 0; trackWaveforms.bgm = t; }
-  }
-  if (Array.isArray(audio?.narration)) {
-    const all = [];
-    for (const n of audio.narration) {
-      const nUrl = n.src || resolveMediaUrl(n.path);
-      if (!nUrl) continue;
-      const t = await computePeaks(nUrl, 80);
-      if (t) { t.t = n.t ?? 0; all.push(t); }
-    }
-    if (all.length) trackWaveforms.narration = { segments: all, color: TRACK_COLORS.narration };
-  }
-  if (Array.isArray(audio?.sfx)) {
-    const all = [];
-    for (const s of audio.sfx) {
-      const sUrl = s.src || resolveMediaUrl(s.path);
-      if (!sUrl) continue;
-      const t = await computePeaks(sUrl, 60);
-      if (t) { t.t = s.t ?? 0; all.push(t); }
-    }
-    if (all.length) trackWaveforms.sfx = { segments: all, color: TRACK_COLORS.sfx };
-  }
-  for (const [name, canvas] of Object.entries(trackCanvases)) {
-    if (!canvas) continue;
-    const track = trackWaveforms[name];
-    const tr = canvas.closest('.waveform-track');
-    if (track) {
-      canvas.width = canvas.clientWidth * devicePixelRatio;
-      canvas.height = canvas.clientHeight * devicePixelRatio;
-      if (tr) tr.hidden = false;
-    } else {
-      if (tr) tr.hidden = true;
-    }
-  }
-  drawWaveform(0);
-  drawTrackWaveforms(0);
-}
-function drawTrackWaveforms(ratio) {
-  for (const [name, canvas] of Object.entries(trackCanvases)) {
-    if (!canvas || !canvas.width) continue;
-    const track = trackWaveforms[name];
-    if (!track) continue;
-    const ctx = canvas.getContext('2d');
-    const w = canvas.width, h = canvas.height;
-    ctx.clearRect(0, 0, w, h);
-    if (track.segments) {
-      for (const seg of track.segments) {
-        if (!seg.peaks) continue;
-        const sx = ((seg.t ?? 0) / totalDuration) * w;
-        const sw = (seg.duration / totalDuration) * w;
-        ctx.fillStyle = track.color;
-        for (let i = 0; i < seg.peaks.length; i++) {
-          const bH = Math.max(1, seg.peaks[i] * (h - 4));
-          ctx.fillRect(sx + (i / seg.peaks.length) * sw, (h - bH) / 2, Math.max(1, sw / seg.peaks.length - 0.5), bH);
-        }
-      }
-    } else if (track.peaks) {
-      const sx = ((track.t ?? 0) / totalDuration) * w;
-      const sw = (track.duration / totalDuration) * w;
-      const barW = sw / track.peaks.length;
-      ctx.fillStyle = track.color;
-      for (let i = 0; i < track.peaks.length; i++) {
-        const bH = Math.max(1, track.peaks[i] * (h - 4));
-        ctx.fillRect(sx + i * barW, (h - bH) / 2, Math.max(1, barW - 0.5), bH);
-      }
-    }
-    if (ratio > 0) { ctx.fillStyle = 'rgba(255,255,255,0.5)'; ctx.fillRect(ratio * w - 0.5, 0, 1, h); }
-  }
-}
-function drawWaveform(ratio) {
-  const ctx = waveformCanvas.getContext('2d');
-  const w = waveformCanvas.width, h = waveformCanvas.height;
-  ctx.clearRect(0, 0, w, h);
-  if (!waveformPeaks) return;
-  const barW = w / waveformPeaks.length, mid = h / 2;
-  ctx.fillStyle = '#888';
-  for (let i = 0; i < waveformPeaks.length; i++) {
-    const bH = Math.max(1, waveformPeaks[i] * (h - 4));
-    ctx.fillRect(i * barW, mid - bH / 2, Math.max(1, barW - 0.5), bH);
-  }
-  if (ratio > 0) { ctx.fillStyle = '#fff'; ctx.fillRect(ratio * w - 0.5, 0, 1, h); }
-}
-
-// Waveform click-to-seek
-waveformCanvas.addEventListener('pointerdown', (e) => {
-  if (!waveformPeaks || totalDuration <= 0) return;
-  const rect = waveformCanvas.getBoundingClientRect();
-  const ratio = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
-  const w = isPlaying; if (w) pause();
-  seekTo(ratio * totalDuration);
-});
-
 function scheduleTransitions() { transitionPlate.style.transition = 'opacity 0.3s'; }
 
 function getVideoTimeForOutput(t) {
@@ -910,6 +868,7 @@ function getActiveSegment(t) {
 }
 
 function seekTo(t) {
+  if (assetPreview) return;
   cutInfoPopup.hidden = true;
   const prev = outputTime;
   outputTime = Math.max(0, Math.min(t, totalDuration));
@@ -917,8 +876,13 @@ function seekTo(t) {
   const vt = getVideoTimeForOutput(outputTime);
   if (vt >= 0) {
     const seg = getActiveSegment(outputTime);
-    if (seg && seg.index >= 0) video.src = getVideoSource(seg.index);
-    video.currentTime = vt;
+    if (seg && seg.index >= 0) {
+      activateSegmentVideo(seg.index, vt);
+    } else if (activeVideoIndex >= 0) {
+      const cur = getActiveVideo();
+      if (cur !== video) cur.style.display = 'none';
+      activeVideoIndex = -1;
+    }
   }
   seek.value = outputTime;
   updateTimeLabel();
@@ -933,6 +897,14 @@ function seekTo(t) {
 }
 
 function play() {
+  if (assetPreview) {
+    const m = assetPreviewMedia();
+    if (m) m.play();
+    playToggle.innerHTML = pauseIcon;
+    playToggle.setAttribute('aria-label', '一時停止');
+    playToggle.title = '一時停止';
+    return;
+  }
   if (isPlaying || !segments.length) return;
   logReviewEvent('play');
   isPlaying = true;
@@ -946,11 +918,9 @@ function play() {
   const pTarget = getVideoTimeForOutput(outputTime);
   const pSeg = getActiveSegment(outputTime);
   if (pTarget >= 0 && pSeg && pSeg.index >= 0) {
-    const pSrc = getVideoSource(pSeg.index);
-    if (pSrc && video.src !== pSrc) video.src = pSrc;
-    video.currentTime = pTarget;
+    activateSegmentVideo(pSeg.index, pTarget);
   }
-  video.play();
+  getActiveVideo().play();
   for (const lv of layerVideos) if (lv.visible) lv.el.play();
   playToggle.innerHTML = pauseIcon;
   playToggle.setAttribute('aria-label', '一時停止');
@@ -958,9 +928,17 @@ function play() {
   requestAnimationFrame(playbackLoop);
 }
 function pause() {
+  if (assetPreview) {
+    const m = assetPreviewMedia();
+    if (m) m.pause();
+    playToggle.innerHTML = playIcon;
+    playToggle.setAttribute('aria-label', '再生');
+    playToggle.title = '再生';
+    return;
+  }
   if (!isPlaying) return;
   logReviewEvent('pause');
-  isPlaying = false; video.pause();
+  isPlaying = false; getActiveVideo().pause();
   for (const lv of layerVideos) lv.el.pause();
   // Mute BGM without destroying source (AudioBufferSourceNode can only start once)
   if (bgmNode) { bgmNode._savedGain ??= bgmNode.gain.value; bgmNode.gain.value = 0; }
@@ -982,15 +960,12 @@ function playbackLoop() {
   const target = getVideoTimeForOutput(outputTime);
   const seg = getActiveSegment(outputTime);
   if (target >= 0 && seg && seg.index >= 0) {
-    const src = getVideoSource(seg.index);
-    if (src && video.src !== src) video.src = src;
-    if (Math.abs(video.currentTime - target) > 0.1) video.currentTime = target;
+    activateSegmentVideo(seg.index, target);
   }
   seek.value = outputTime;
   updateTimeLabel();
   updateStatusBar();
   updateOverlays();
-  updateWaveformPlayhead();
   updateCaption();
   syncCaptionAnimations();
   updateTransitions();
@@ -1000,19 +975,6 @@ function playbackLoop() {
   const tickNow = performance.now();
   if (tickNow - wsTickLast > 200) { sendWsTick(); wsTickLast = tickNow; }
   requestAnimationFrame(playbackLoop);
-}
-
-function updateWaveformPlayhead() {
-  if (!waveformPeaks || totalDuration <= 0) return;
-  const r = outputTime / totalDuration;
-  drawWaveform(r);
-  drawTrackWaveforms(r);
-  waveformPlayhead.style.left = `${r * 100}%`;
-  for (const canvas of Object.values(trackCanvases)) {
-    if (!canvas) continue;
-    const ph = canvas.parentElement?.querySelector('.transport-waveform-playhead');
-    if (ph) ph.style.left = `${r * 100}%`;
-  }
 }
 
 function updateTransitions() {
@@ -1120,6 +1082,7 @@ function syncTracksFromCuts(edit) {
 }
 
 function showCutInfoAt(t) {
+  if (!editMode) { cutInfoPopup.hidden = true; selectedCutIndex = -1; return; }
   let acc = 0;
   for (const seg of segments) {
     if (t <= acc + seg.durationSec || seg === segments[segments.length - 1]) {
@@ -1200,6 +1163,7 @@ function renderCutInfoContent(seg) {
   document.getElementById('cut-delete-btn').addEventListener('click', () => deleteCut(selectedCutIndex));
   document.getElementById('cut-apply-btn').addEventListener('click', async () => {
     if (selectedCutIndex < 0) return;
+    if (!requireTimelineEdit()) return;
     const inVal = Number(document.getElementById('cut-inp-in').value);
     const outVal = Number(document.getElementById('cut-inp-out').value);
     const speedVal = Number(document.getElementById('cut-inp-speed').value);
@@ -1238,6 +1202,7 @@ function renderCutInfoContent(seg) {
 async function addCutAt(index, where) {
   const cuts = summary?.cuts;
   if (!Array.isArray(cuts) || index < 0) return;
+  if (!requireTimelineEdit()) return;
   const ref = cuts[index];
   if (!ref) return;
   const inSec = where === 'before' ? ref.in : ref.out;
@@ -1262,6 +1227,7 @@ async function addCutAt(index, where) {
 async function moveCut(index, dir) {
   const cuts = summary?.cuts;
   if (!Array.isArray(cuts) || index < 0) return;
+  if (!requireTimelineEdit()) return;
   const target = index + dir;
   if (target < 0 || target >= cuts.length) return;
   const newCuts = [...cuts];
@@ -1283,6 +1249,7 @@ async function moveCut(index, dir) {
 async function deleteCut(index) {
   const cuts = summary?.cuts;
   if (!Array.isArray(cuts) || index < 0 || cuts.length <= 1) return;
+  if (!requireTimelineEdit()) return;
   const newCuts = [...cuts.slice(0, index), ...cuts.slice(index + 1)];
   const body = { ...JSON.parse(JSON.stringify(summary)), cuts: newCuts };
   syncTracksFromCuts(body);
@@ -1308,13 +1275,26 @@ seekVisual.addEventListener('click', (e) => {
   if (w) play();
 });
 
-playToggle.addEventListener('click', () => isPlaying ? pause() : play());
-frameBack.addEventListener('click', () => { pause(); seekTo(0); });
-frameForward.addEventListener('click', () => { pause(); seekTo(totalDuration); });
-skipBack.addEventListener('click', () => { pause(); seekTo(outputTime - 10); });
-skipForward.addEventListener('click', () => { pause(); seekTo(outputTime + 10); });
+playToggle.addEventListener('click', () => {
+  if (assetPreview) {
+    const m = assetPreviewMedia();
+    if (m && !m.paused) pause(); else play();
+    return;
+  }
+  isPlaying ? pause() : play();
+});
+frameBack.addEventListener('click', () => { if (assetPreview) { assetSeekTo(0); return; } pause(); seekTo(0); });
+frameForward.addEventListener('click', () => { if (assetPreview) { const m = assetPreviewMedia(); assetSeekTo(assetMediaDuration(m)); return; } pause(); seekTo(totalDuration); });
+skipBack.addEventListener('click', () => { if (assetPreview) { const m = assetPreviewMedia(); assetSeekTo((Number.isFinite(m?.currentTime) ? m.currentTime : 0) - 10); return; } pause(); seekTo(outputTime - 10); });
+skipForward.addEventListener('click', () => { if (assetPreview) { const m = assetPreviewMedia(); assetSeekTo((Number.isFinite(m?.currentTime) ? m.currentTime : 0) + 10); return; } pause(); seekTo(outputTime + 10); });
 seek.addEventListener('input', () => {
   const t = Number(seek.value);
+  if (assetPreview) {
+    const m = assetPreviewMedia();
+    if (m) m.currentTime = t;
+    updateAssetSeekUI();
+    return;
+  }
   const w = isPlaying; if (w) pause();
   seekTo(t);
   showCutInfoAt(t);
@@ -1336,13 +1316,13 @@ function snapToCut(t, dir) {
 document.addEventListener('keydown', (e) => {
   if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT') return;
   switch (e.code) {
-    case 'Space': e.preventDefault(); isPlaying ? pause() : play(); break;
-    case 'ArrowLeft': e.preventDefault(); pause(); seekTo(outputTime - 1 / fps); break;
-    case 'ArrowRight': e.preventDefault(); pause(); seekTo(outputTime + 1 / fps); break;
-    case 'ArrowUp': e.preventDefault(); pause(); seekTo(outputTime - 10); break;
-    case 'ArrowDown': e.preventDefault(); pause(); seekTo(outputTime + 10); break;
-    case 'Home': e.preventDefault(); seekTo(0); break;
-    case 'End': e.preventDefault(); seekTo(totalDuration); break;
+    case 'Space': e.preventDefault(); if (assetPreview) { const m = assetPreviewMedia(); if (m && !m.paused) pause(); else play(); } else { isPlaying ? pause() : play(); } break;
+    case 'ArrowLeft': e.preventDefault(); if (assetPreview) { assetSeekTo((Number.isFinite(assetPreviewMedia()?.currentTime) ? assetPreviewMedia().currentTime : 0) - 1 / fps); } else { pause(); seekTo(outputTime - 1 / fps); } break;
+    case 'ArrowRight': e.preventDefault(); if (assetPreview) { assetSeekTo((Number.isFinite(assetPreviewMedia()?.currentTime) ? assetPreviewMedia().currentTime : 0) + 1 / fps); } else { pause(); seekTo(outputTime + 1 / fps); } break;
+    case 'ArrowUp': e.preventDefault(); if (assetPreview) { assetSeekTo((Number.isFinite(assetPreviewMedia()?.currentTime) ? assetPreviewMedia().currentTime : 0) - 10); } else { pause(); seekTo(outputTime - 10); } break;
+    case 'ArrowDown': e.preventDefault(); if (assetPreview) { assetSeekTo((Number.isFinite(assetPreviewMedia()?.currentTime) ? assetPreviewMedia().currentTime : 0) + 10); } else { pause(); seekTo(outputTime + 10); } break;
+    case 'Home': e.preventDefault(); if (assetPreview) { assetSeekTo(0); } else { seekTo(0); } break;
+    case 'End': e.preventDefault(); if (assetPreview) { assetSeekTo(assetMediaDuration(assetPreviewMedia())); } else { seekTo(totalDuration); } break;
     case 'KeyS': e.preventDefault(); pause(); tlSplitCut(outputTime); break;
     case 'Delete':
     case 'Backspace': e.preventDefault(); pause(); tlDeleteCut(outputTime); break;
@@ -1363,7 +1343,10 @@ video.addEventListener('error', () => { loadingIndicator.style.display = 'none';
 const penToggle = document.getElementById('pen-toggle');
 penToggle.addEventListener('click', () => {
   const next = !penActive;
-  if (next) { editMode = false; editToggle.setAttribute('aria-pressed', 'false'); stage.style.pointerEvents = 'none'; clearSelection(); captionEnable(false); }
+  if (next) {
+    if (!editMode) { editMode = true; editToggle.setAttribute('aria-pressed', 'true'); stage.style.pointerEvents = 'auto'; updateLayerPointerEvents(); }
+    captionEnable(false);
+  }
   penToggle.setAttribute('aria-pressed', String(next));
   penEnable(next);
   if (next) zoomLayer.style.cursor = 'crosshair';
@@ -1430,7 +1413,10 @@ function updateCaptionSelectBox() {
 
 captionToggle.addEventListener('click', () => {
   const next = !captionEditMode;
-  if (next) { editMode = false; editToggle.setAttribute('aria-pressed', 'false'); stage.style.pointerEvents = 'none'; clearSelection(); penEnable(false); }
+  if (next) {
+    if (!editMode) { editMode = true; editToggle.setAttribute('aria-pressed', 'true'); stage.style.pointerEvents = 'auto'; updateLayerPointerEvents(); }
+    penEnable(false);
+  }
   captionEnable(next);
 });
 captionPlate.addEventListener('pointerdown', (e) => {
@@ -1476,6 +1462,7 @@ captionPlate.addEventListener('pointerdown', (e) => {
     cleanup();
     if (!moved || candidateZone === origZone) { updateCaptionSelectBox(); return; }
     (async () => {
+      if (!requireEditMode()) return;
       const cap = summary?.captions?.find(c => c.id === selectedCaptionId);
       if (!cap) return;
       const ts = { ...(cap.text_style || {}), zone: candidateZone };
@@ -1497,6 +1484,7 @@ captionPlate.addEventListener('pointerdown', (e) => {
 // Caption style editing via popup
 captionZoneSelect.addEventListener('change', async () => {
   if (!selectedCaptionId) return;
+  if (!requireEditMode()) return;
   const zone = captionZoneSelect.value;
   const cap = summary?.captions?.find(c => c.id === selectedCaptionId);
   if (!cap) return;
@@ -1512,6 +1500,7 @@ captionZoneSelect.addEventListener('change', async () => {
 });
 captionColorInput.addEventListener('change', async () => {
   if (!selectedCaptionId) return;
+  if (!requireEditMode()) return;
   const color = captionColorInput.value;
   const cap = summary?.captions?.find(c => c.id === selectedCaptionId);
   if (!cap) return;
@@ -1527,6 +1516,7 @@ captionColorInput.addEventListener('change', async () => {
 });
 captionSizeInput.addEventListener('change', async () => {
   if (!selectedCaptionId) return;
+  if (!requireEditMode()) return;
   const size_px = Number(captionSizeInput.value);
   const cap = summary?.captions?.find(c => c.id === selectedCaptionId);
   if (!cap) return;
@@ -1761,16 +1751,38 @@ function updateLayerPointerEvents() {
 }
 
 // --- Edit mode ---
+const VIEWER_MODE = window.__VIEWER_MODE__ === true;
 let transformDirty = false;
+window.akari = window.akari || {};
+window.akari.editMode = () => editMode;
+function requireEditMode(msg) {
+  if (editMode) return true;
+  showMessage(msg || '編集モードをオンにしてください');
+  return false;
+}
+function requireTimelineEdit(msg) {
+  if (VIEWER_MODE) {
+    showMessage(msg || 'Viewer モードでは編集できません');
+    return false;
+  }
+  return true;
+}
 editToggle.addEventListener('click', () => {
   editMode = !editMode;
-  if (editMode) { penEnable(false); captionEnable(false); }
   editToggle.setAttribute('aria-pressed', String(editMode));
   stage.style.pointerEvents = editMode ? 'auto' : 'none';
   updateLayerPointerEvents();
-  if (!editMode) { clearSelection(); clearLayerSelection(); }
+  if (!editMode) { clearSelection(); clearLayerSelection(); penEnable(false); captionEnable(false); }
   if (editMode && selectedLayerId) updateLayerSelectBox();
 });
+if (VIEWER_MODE) {
+  editToggle.disabled = true;
+  editToggle.title = '編集 (Viewer モード)';
+  for (const id of ['review-record-btn', 'output-preview-btn', 'pen-toggle', 'caption-toggle', 'fullscreen-toggle', 'indicator-toggle']) {
+    const el = document.getElementById(id);
+    if (el) el.hidden = true;
+  }
+}
 function clearSelection() {
   selectedId = null; selectedKind = null;
   selectionLabel.textContent = ''; transformPopup.hidden = true;
@@ -1806,6 +1818,7 @@ function showTransform(t) {
   });
 });
 async function writeEditJson(kind, id, patch) {
+  if (!editMode) return;
   try {
     const res = await fetch(api.summary);
     const edit = await res.json();
@@ -1839,29 +1852,23 @@ function renderIndicators() {
   indicatorPopup.innerHTML = ind.map(i => `<div class="indicator-item"><span class="key">${esc(i)}</span></div>`).join('');
 }
 
-// --- Waveform toggle ---
-let waveformVisible = false;
-waveformToggle.addEventListener('click', () => {
-  waveformVisible = !waveformVisible;
-  waveformRow.hidden = !waveformVisible;
-  waveformToggle.setAttribute('aria-pressed', String(waveformVisible));
-  saveSettings({ waveformVisible });
-  if (waveformVisible) setupWaveform();
-});
-
 // --- Zoom ---
 const ZOOM_MIN = 0.25, ZOOM_MAX = 8;
+const zoomFitBtn = document.getElementById('zoom-fit');
 function updateZoom() {
   zoomLayer.style.transform = `scale(${zoom}) translate(${pan.x}px, ${pan.y}px)`;
-  zoomValue.textContent = `${Math.round(zoom * 100)}%`;
+  zoomValue.textContent = zoom === 1 ? '画面に合わせる' : `${Math.round(zoom * 100)}%`;
   zoomSlider.value = Math.log2(zoom / ZOOM_MIN) / Math.log2(ZOOM_MAX / ZOOM_MIN);
+  zoomFitBtn.classList.toggle('is-active', zoom === 1);
   updateMinimap();
+  applyAssetPreviewZoom();
 }
 zoomToggle.addEventListener('click', () => { const o = !zoomPopup.hidden; zoomPopup.hidden = o; zoomToggle.setAttribute('aria-expanded', String(!o)); });
 zoomSlider.addEventListener('input', () => { zoom = ZOOM_MIN * Math.pow(ZOOM_MAX / ZOOM_MIN, Number(zoomSlider.value)); pan = { x: 0, y: 0 }; updateZoom(); saveSettings({ zoom }); });
 document.querySelectorAll('.zoom-preset').forEach(btn => {
   btn.addEventListener('click', () => { zoom = Number(btn.dataset.zoom); pan = { x: 0, y: 0 }; updateZoom(); zoomPopup.hidden = true; zoomToggle.setAttribute('aria-expanded', 'false'); saveSettings({ zoom }); });
 });
+zoomFitBtn.addEventListener('click', () => { zoom = 1; pan = { x: 0, y: 0 }; updateZoom(); zoomPopup.hidden = true; zoomToggle.setAttribute('aria-expanded', 'false'); saveSettings({ zoom }); });
 wrapper.addEventListener('wheel', (e) => {
   if (!e.ctrlKey && !e.metaKey) return;
   e.preventDefault();
@@ -1880,6 +1887,60 @@ fullscreenToggle.addEventListener('click', () => {
   if (document.fullscreenElement) { document.exitFullscreen(); fullscreenToggle.innerHTML = fullscreenIcon; fullscreenToggle.setAttribute('aria-pressed', 'false'); }
   else { wrapper.requestFullscreen(); fullscreenToggle.innerHTML = restoreIcon; fullscreenToggle.setAttribute('aria-pressed', 'true'); }
 });
+
+// --- Pane resize ---
+const paneLeftResize = document.querySelector('.pane-left-resize');
+const paneBottomResize = document.querySelector('.pane-bottom-resize');
+const PANE_LEFT_MIN = 160;
+const PANE_LEFT_MAX = 500;
+const PANE_BOTTOM_MIN = 80;
+const PANE_BOTTOM_MAX = 600;
+
+function initPaneResize() {
+  if (paneLeftResize) {
+    paneLeftResize.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      paneLeftResize.classList.add('is-dragging');
+      const startX = e.clientX;
+      const startWidth = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--pane-left-width')) || 260;
+      function onMove(ev) {
+        const w = Math.max(PANE_LEFT_MIN, Math.min(PANE_LEFT_MAX, startWidth + ev.clientX - startX));
+        document.documentElement.style.setProperty('--pane-left-width', w + 'px');
+      }
+      function onUp() {
+        paneLeftResize.classList.remove('is-dragging');
+        document.removeEventListener('pointermove', onMove);
+        document.removeEventListener('pointerup', onUp);
+        const finalW = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--pane-left-width'));
+        if (Number.isFinite(finalW)) saveSettings({ paneLeftWidth: finalW });
+      }
+      document.addEventListener('pointermove', onMove);
+      document.addEventListener('pointerup', onUp);
+    });
+  }
+  if (paneBottomResize) {
+    paneBottomResize.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      paneBottomResize.classList.add('is-dragging');
+      const startY = e.clientY;
+      const startHeight = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--pane-bottom-height')) || 220;
+      function onMove(ev) {
+        const h = Math.max(PANE_BOTTOM_MIN, Math.min(PANE_BOTTOM_MAX, startHeight + startY - ev.clientY));
+        document.documentElement.style.setProperty('--pane-bottom-height', h + 'px');
+      }
+      function onUp() {
+        paneBottomResize.classList.remove('is-dragging');
+        document.removeEventListener('pointermove', onMove);
+        document.removeEventListener('pointerup', onUp);
+        const finalH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--pane-bottom-height'));
+        if (Number.isFinite(finalH)) saveSettings({ paneBottomHeight: finalH });
+      }
+      document.addEventListener('pointermove', onMove);
+      document.addEventListener('pointerup', onUp);
+    });
+  }
+}
+initPaneResize();
 
 // --- Overlay runtime ---
 function createOverlayRuntime() {
@@ -2124,7 +2185,17 @@ function syncCaptionAnimations() {
 }
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
-function showMessage(text) { if (text) { previewMessage.hidden = false; previewMessageText.textContent = text; } else { previewMessage.hidden = true; } }
+let messageTimer = null;
+function showMessage(text) {
+  if (messageTimer) { clearTimeout(messageTimer); messageTimer = null; }
+  if (!text) { toast.hidden = true; return; }
+  toast.textContent = text;
+  toast.hidden = false;
+  toast.classList.remove('show');
+  void toast.offsetWidth;
+  toast.classList.add('show');
+  messageTimer = setTimeout(() => { toast.hidden = true; }, 2500);
+}
 
 let wsTickLast = 0;
 function connectWs() {
@@ -2287,7 +2358,7 @@ function renderAssets() {
     return;
   }
   assetList.innerHTML = filtered.map(a => `
-    <div class="asset-item" draggable="true" data-path="${a.path}" data-category="${a.category}">
+    <div class="asset-item${assetPreview?.path === a.path ? ' selected' : ''}" draggable="true" data-path="${a.path}" data-category="${a.category}">
       <div class="asset-icon ${a.category}">${ASSET_ICONS[a.category] || '📄'}</div>
       <div class="asset-info">
         <div class="asset-name">${esc(a.name)}</div>
@@ -2306,6 +2377,144 @@ function renderAssets() {
   });
 }
 
+// --- Asset preview ---
+const assetPreviewEl = document.getElementById('asset-preview');
+const assetPreviewImage = document.getElementById('asset-preview-image');
+const assetPreviewVideo = document.getElementById('asset-preview-video');
+const assetPreviewAudio = document.getElementById('asset-preview-audio');
+const assetPreviewNote = document.getElementById('asset-preview-note');
+const assetPreviewLabel = document.getElementById('asset-preview-label');
+
+function assetPreviewMedia() {
+  if (!assetPreview) return null;
+  return assetPreview.category === 'audio' ? assetPreviewAudio : assetPreviewVideo;
+}
+
+assetPreviewAudio.addEventListener('play', () => assetPreviewNote.classList.add('playing'));
+assetPreviewAudio.addEventListener('pause', () => assetPreviewNote.classList.remove('playing'));
+
+function applyAssetPreviewZoom() {
+  if (!assetPreview) return;
+  const target = assetPreview.category === 'image' ? assetPreviewImage : assetPreviewVideo;
+  if (target.hidden) return;
+  target.style.transformOrigin = 'center';
+  target.style.transform = `scale(${zoom}) translate(${pan.x}px, ${pan.y}px)`;
+}
+
+function assetMediaDuration(m) {
+  const d = m?.duration;
+  return Number.isFinite(d) && d > 0 ? d : 0;
+}
+
+function updateAssetSeekUI() {
+  if (!assetPreview) return;
+  const m = assetPreviewMedia();
+  const dur = assetMediaDuration(m);
+  const ct = m && Number.isFinite(m.currentTime) ? m.currentTime : 0;
+  seek.max = dur || 0;
+  seek.value = Math.min(ct, dur || ct);
+  timeLabel.textContent = `${fm(ct)} / ${fm(dur)}`;
+}
+
+function assetSeekTo(t) {
+  if (!assetPreview) return;
+  const m = assetPreviewMedia();
+  const dur = assetMediaDuration(m);
+  if (!m || !dur) return;
+  m.currentTime = Math.max(0, Math.min(dur, t));
+  updateAssetSeekUI();
+}
+
+function updateAssetSelection() {
+  if (!assetList) return;
+  assetList.querySelectorAll('.asset-item').forEach(el => {
+    el.classList.toggle('selected', !!assetPreview && el.dataset.path === assetPreview.path);
+  });
+}
+
+function enterAssetPreview(path, name, category) {
+  if (assetPreview?.path === path) { exitAssetPreview(); return; }
+  if (isPlaying) pause();
+  assetPreview = { path, name, category, url: resolveMediaUrl(path) };
+  assetPreviewVideo.pause();
+  assetPreviewVideo.removeAttribute('src');
+  assetPreviewVideo.load();
+  assetPreviewAudio.pause();
+  assetPreviewAudio.removeAttribute('src');
+  assetPreviewAudio.load();
+  playToggle.innerHTML = playIcon;
+  playToggle.setAttribute('aria-label', '再生');
+  playToggle.title = '再生';
+  assetPreviewImage.removeAttribute('src');
+  assetPreviewImage.hidden = true;
+  assetPreviewVideo.hidden = true;
+  assetPreviewAudio.hidden = true;
+  assetPreviewNote.hidden = true;
+  assetPreviewNote.classList.remove('playing');
+  if (category === 'image') {
+    assetPreviewImage.src = assetPreview.url;
+    assetPreviewImage.hidden = false;
+  } else if (category === 'audio') {
+    assetPreviewAudio.src = assetPreview.url;
+    assetPreviewAudio.hidden = false;
+    assetPreviewNote.hidden = false;
+  } else {
+    assetPreviewVideo.src = assetPreview.url;
+    assetPreviewVideo.hidden = false;
+  }
+  assetPreviewLabel.textContent = name;
+  assetPreviewEl.hidden = false;
+  minimap.hidden = true;
+  seekVisual.style.display = 'none';
+  updateAssetSeekUI();
+  applyAssetPreviewZoom();
+  updateAssetSelection();
+}
+
+function exitAssetPreview() {
+  if (!assetPreview) return;
+  assetPreviewVideo.pause();
+  assetPreviewVideo.removeAttribute('src');
+  assetPreviewVideo.load();
+  assetPreviewAudio.pause();
+  assetPreviewAudio.removeAttribute('src');
+  assetPreviewAudio.load();
+  assetPreviewImage.removeAttribute('src');
+  assetPreviewVideo.style.transform = '';
+  assetPreviewImage.style.transform = '';
+  assetPreviewNote.hidden = true;
+  assetPreviewNote.classList.remove('playing');
+  assetPreviewEl.hidden = true;
+  assetPreview = null;
+  seek.max = totalDuration || 0;
+  seek.value = outputTime;
+  updateTimeLabel();
+  updateSeekVisual();
+  updateAssetSelection();
+  updateMinimap();
+  seekTo(outputTime);
+}
+
+function setupAssetPreview() {
+  for (const m of [assetPreviewVideo, assetPreviewAudio]) {
+    m.addEventListener('play', () => {
+      if (!assetPreview) return;
+      playToggle.innerHTML = pauseIcon;
+      playToggle.setAttribute('aria-label', '一時停止');
+      playToggle.title = '一時停止';
+    });
+    m.addEventListener('pause', () => {
+      if (!assetPreview) return;
+      playToggle.innerHTML = playIcon;
+      playToggle.setAttribute('aria-label', '再生');
+      playToggle.title = '再生';
+    });
+    m.addEventListener('loadedmetadata', () => { if (assetPreview) updateAssetSeekUI(); });
+    m.addEventListener('durationchange', () => { if (assetPreview) updateAssetSeekUI(); });
+    m.addEventListener('timeupdate', () => { if (assetPreview) updateAssetSeekUI(); });
+  }
+}
+
 function setupAssetBrowser() {
   // Tabs
   for (const tab of assetTabs) {
@@ -2321,11 +2530,15 @@ function setupAssetBrowser() {
     assetFilterText = assetSearch.value.toLowerCase();
     renderAssets();
   });
-  // Click to show in editor (add to sources or navigate)
+  // Click to preview asset in the preview window (video/audio/image aware)
   assetList.addEventListener('click', (e) => {
     const item = e.target.closest('.asset-item');
     if (!item) return;
     showMessage(null);
+    const path = item.dataset.path;
+    const name = item.querySelector('.asset-name')?.textContent || path.split('/').pop();
+    const category = item.dataset.category || 'video';
+    enterAssetPreview(path, name, category);
   });
 
   // Asset context menu (right-click)
@@ -2339,16 +2552,20 @@ function setupAssetBrowser() {
   };
 
   function buildAssetCtxMenu(path, name, category) {
-    const otherTracks = (summary?.tracks || []).filter(t => !t.isMain);
-    let html = `<button class="ctx-actx" data-action="main">メインタイムラインに追加</button>`;
-    if (otherTracks.length > 0) {
-      html += `<div class="ctx-section-title">既存トラックに追加:</div>`;
-      for (const t of otherTracks) {
-        html += `<button class="ctx-actx" data-action="track" data-id="${t.id}">${esc(t.label)}</button>`;
+    let html = '';
+    if (!VIEWER_MODE) {
+      const otherTracks = (summary?.tracks || []).filter(t => !t.isMain);
+      html = `<button class="ctx-actx" data-action="main">メインタイムラインに追加</button>`;
+      if (otherTracks.length > 0) {
+        html += `<div class="ctx-section-title">既存トラックに追加:</div>`;
+        for (const t of otherTracks) {
+          html += `<button class="ctx-actx" data-action="track" data-id="${t.id}">${esc(t.label)}</button>`;
+        }
       }
+      html += `<button class="ctx-actx" data-action="new">＋ 新規トラックを作成し追加</button>`;
+      html += `<hr>`;
     }
-    html += `<button class="ctx-actx" data-action="new">＋ 新規トラックを作成し追加</button>`;
-    html += `<hr><button class="ctx-actx" data-action="copy">ファイル名をコピー</button>`;
+    html += `<button class="ctx-actx" data-action="copy">ファイル名をコピー</button>`;
     assetCtx.innerHTML = html;
     assetCtx._path = path;
     assetCtx._name = name;
@@ -2385,6 +2602,7 @@ function setupAssetBrowser() {
     }
 
     if (!path || !summary?.cuts) return;
+    if (!requireTimelineEdit()) return;
     const t = outputTime;
     const srcId = 'src-' + Date.now();
 
@@ -2570,6 +2788,7 @@ function showAddTrackDialog(opts) {
 
 function addTrack() {
   if (!summary?.tracks) return;
+  if (!requireTimelineEdit()) return;
   showAddTrackDialog({ defaultType: 'video', defaultName: '' }).then(result => {
     if (!result) return;
     const { type, name } = result;
@@ -2592,6 +2811,7 @@ function addTrack() {
 
 async function removeTrack(trackId) {
   if (!summary?.tracks) return;
+  if (!requireTimelineEdit()) return;
   const idx = summary.tracks.findIndex(t => t.id === trackId);
   if (idx < 0) return;
   const track = summary.tracks[idx];
@@ -2610,6 +2830,7 @@ async function removeTrack(trackId) {
 
 async function renameTrack(trackId, newLabel) {
   if (!summary?.tracks) return;
+  if (!requireTimelineEdit()) return;
   const track = summary.tracks.find(t => t.id === trackId);
   if (!track) return;
   track.label = newLabel;
@@ -2661,9 +2882,9 @@ function tlHitTest(px, py) {
   const numTracks = getTimelineTrackCount();
   if (py < 0 || py > TL_TRACK_HEIGHT * numTracks) return null;
   const trackN = Math.floor(py / TL_TRACK_HEIGHT);
-  const tracks = summary?.tracks?.filter(t => t.type === 'video') || [];
-  const track = tracks[trackN];
-  if (!track) return null;
+  const allTracks = summary?.tracks || [];
+  const track = allTracks[trackN];
+  if (!track || track.type !== 'video') return null;
   if (track.isMain) {
     // Main track hit test using segments
     let cursor = 0;
@@ -2705,14 +2926,15 @@ function tlHitTest(px, py) {
 
 const TL_SNAP_PX = 6;
 
-function tlSnapTime(t, excludeIndex) {
+function tlSnapTime(t, excludeIndexOrList) {
   let bestSnap = null;
   let bestDist = TL_SNAP_PX / tlZoom;
+  const excludes = Array.isArray(excludeIndexOrList) ? excludeIndexOrList : (excludeIndexOrList == null ? [] : [excludeIndexOrList]);
   let cursor = 0;
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i];
     if (seg.isGap) { cursor += seg.durationSec; continue; }
-    if (seg.index === excludeIndex) { cursor += seg.durationSec; continue; }
+    if (excludes.includes(seg.index)) { cursor += seg.durationSec; continue; }
     [cursor, cursor + seg.durationSec].forEach(b => {
       const d = Math.abs(t - b);
       if (d < bestDist) { bestDist = d; bestSnap = b; }
@@ -2722,7 +2944,54 @@ function tlSnapTime(t, excludeIndex) {
   return bestSnap;
 }
 
+// Rolling boundary trim: dragging the boundary between two adjacent clips moves
+// ONLY that boundary. Both adjacent clips change length (left grows / right
+// shrinks by the same timeline delta) and all other clips stay in place.
+function applyBoundaryTrim(edit, drag, deltaFrames, fps) {
+  const cuts = edit.cuts;
+  const cut = cuts[drag.cutIndex];
+  if (!cut) return;
+  const minDur = 1 / (fps || 30);
+
+  let left, right, leftStartOut, rightStartIn, lSpeed, rSpeed, leftDurStart, rightDurStart;
+  if (drag.mode === 'trim-out') {
+    left = cut; right = cuts[drag.cutIndex + 1];
+    leftStartOut = drag.startOut; rightStartIn = drag.neighborIn;
+  } else {
+    left = cuts[drag.cutIndex - 1]; right = cut;
+    leftStartOut = drag.neighborOut; rightStartIn = drag.startIn;
+  }
+  // Rolling edit only applies to contiguous clips in a relative (no `at`) layout.
+  // First/last clips and absolute (`at`) layouts fall back to a plain source trim.
+  if (!left || !right || drag.hasAt || drag.neighborHasAt) {
+    if (drag.mode === 'trim-out') {
+      cut.out = Math.max(cut.in + minDur, +(drag.startOut + deltaFrames).toFixed(2));
+    } else {
+      cut.in = Math.max(0, Math.min(cut.out - minDur, +(drag.startIn + deltaFrames).toFixed(2)));
+    }
+    return;
+  }
+
+  lSpeed = left.speed || 1;
+  rSpeed = right.speed || 1;
+  leftDurStart = (drag.mode === 'trim-out' ? drag.startOut - drag.startIn : drag.neighborOut - drag.neighborIn) / lSpeed;
+  rightDurStart = (drag.mode === 'trim-out' ? drag.neighborOut - drag.neighborIn : drag.startOut - drag.startIn) / rSpeed;
+
+  let d = deltaFrames;
+  d = Math.max(d, -(leftDurStart - minDur));
+  d = Math.min(d, rightDurStart - minDur);
+  const snap = tlSnapTime(drag.boundaryStart + d, [drag.cutIndex - 1, drag.cutIndex, drag.cutIndex + 1]);
+  if (snap !== null) {
+    d = snap - drag.boundaryStart;
+    d = Math.max(d, -(leftDurStart - minDur));
+    d = Math.min(d, rightDurStart - minDur);
+  }
+  left.out = +(leftStartOut + d * lSpeed).toFixed(3);
+  right.in = Math.max(0, +(rightStartIn + d * rSpeed).toFixed(3));
+}
+
 async function tlSplitCut(t) {
+  if (!requireTimelineEdit()) return;
   const seg = getActiveSegment(t);
   if (!seg || seg.isGap || !summary?.cuts?.[seg.index]) return;
   let cursor = 0;
@@ -2748,6 +3017,7 @@ async function tlSplitCut(t) {
 }
 
 async function tlDeleteCut(t) {
+  if (!requireTimelineEdit()) return;
   const seg = getActiveSegment(t);
   if (!seg || seg.isGap || !summary?.cuts?.[seg.index]) return;
   const newEdit = JSON.parse(JSON.stringify(summary));
@@ -2768,14 +3038,19 @@ function setupTimeline() {
   tlFitBtn.addEventListener('click', () => { tlZoom = computeNaturalZoom(); renderTimeline(); });
   tlCanvasWrap.addEventListener('scroll', () => { tlScrollLeft = tlCanvasWrap.scrollLeft; updateTimelinePlayhead(); });
 
-  // Add track button — near タイムライン label
+  // Clicking any timeline element returns the preview window to the timeline
+  document.getElementById('timeline-pane').addEventListener('click', () => {
+    if (assetPreview) exitAssetPreview();
+  });
+
+  // Add track button — before "タイムライン" label
   const addTrackBtn = document.createElement('button');
   addTrackBtn.className = 'tl-btn';
-  addTrackBtn.textContent = '+';
   addTrackBtn.title = 'トラックを追加';
-  addTrackBtn.style.cssText = 'margin-left:4px;font-weight:bold';
+  addTrackBtn.style.cssText = 'margin-right:6px;vertical-align:middle';
+  addTrackBtn.innerHTML = `<svg viewBox="0 0 20 20" width="16" height="16" fill="none" stroke="#ccc" stroke-width="1.5" stroke-linecap="round"><line x1="3" y1="4" x2="17" y2="4"/><line x1="5" y1="10" x2="17" y2="10"/><line x1="3" y1="16" x2="17" y2="16"/><circle cx="3" cy="4" r="2" fill="#4da3ff" stroke="none"/></svg>`;
   addTrackBtn.addEventListener('click', () => addTrack());
-  document.querySelector('#timeline-pane .pane-header span')?.after(addTrackBtn);
+  document.querySelector('#timeline-pane .pane-header span')?.before(addTrackBtn);
 
   // Pointer interaction: trim / move / seek
   tlCanvas.addEventListener('pointerdown', (e) => {
@@ -2783,7 +3058,7 @@ function setupTimeline() {
     const px = tlTimelineX(e);
     const py = e.clientY - tlCanvas.getBoundingClientRect().top;
     const hit = tlHitTest(px, py);
-    if (!hit || hit.mode === 'move' && hit.segIndex < 0) {
+    if (VIEWER_MODE || !hit || hit.mode === 'move' && hit.segIndex < 0) {
       // seek
       const t = tlTimeFromX(px);
       const w = isPlaying; if (w) pause();
@@ -2793,12 +3068,19 @@ function setupTimeline() {
     const seg = segments[hit.segIndex];
     const cut = summary?.cuts?.[hit.cutIndex];
     if (!cut) return;
+    const neighborIdx = hit.mode === 'trim-out' ? hit.cutIndex + 1 : hit.cutIndex - 1;
+    const neighbor = summary?.cuts?.[neighborIdx];
     tlDrag = {
       mode: hit.mode, segIndex: hit.segIndex, cutIndex: hit.cutIndex,
       startPx: px,
       startIn: cut.in, startOut: cut.out,
       startSegIn: seg.inSec, startSegOut: seg.outSec,
       startAt: cut.at !== undefined ? cut.at : hit.cursor,
+      hasAt: cut.at !== undefined,
+      neighborIndex: neighborIdx,
+      neighborIn: neighbor?.in, neighborOut: neighbor?.out,
+      neighborHasAt: neighbor?.at !== undefined,
+      boundaryStart: hit.mode === 'trim-out' ? hit.cursor + seg.durationSec : hit.cursor,
       saved: false, moved: false,
       cursorStart: hit.cursor,
     };
@@ -2810,6 +3092,7 @@ function setupTimeline() {
 
   tlCanvas.addEventListener('contextmenu', (e) => {
     e.preventDefault();
+    if (!editMode) return;
     const px = tlTimelineX(e);
     const py = e.clientY - tlCanvas.getBoundingClientRect().top;
     const hit = tlHitTest(px, py);
@@ -2841,7 +3124,7 @@ function setupTimeline() {
       const px = tlTimelineX(e);
       const py = e.offsetY || (e.clientY - tlCanvas.getBoundingClientRect().top);
       const hit = tlHitTest(px, py);
-      tlCanvas.style.cursor = hit ? (hit.mode === 'trim-in' || hit.mode === 'trim-out' ? 'ew-resize' : 'grab') : 'default';
+      tlCanvas.style.cursor = editMode && hit ? (hit.mode === 'trim-in' || hit.mode === 'trim-out' ? 'ew-resize' : 'grab') : 'default';
       // Cut info popup on hover
       const infoPopup = document.getElementById('cut-info-popup');
       const infoContent = document.getElementById('cut-info-content');
@@ -2866,40 +3149,24 @@ function setupTimeline() {
     const deltaSec = (px - tlDrag.startPx) / tlZoom;
     const deltaFrames = Math.round(deltaSec * fps) / fps;
     const newEdit = JSON.parse(JSON.stringify(summary));
-    const cut = newEdit.cuts[tlDrag.cutIndex];
-    if (!cut) return;
     if (Math.abs(px - tlDrag.startPx) > 3) tlDrag.moved = true;
-    if (tlDrag.mode === 'trim-in') {
-      const newIn = Math.max(0, +(tlDrag.startIn + deltaFrames).toFixed(2));
-      if (newIn < cut.out - (1 / fps)) cut.in = newIn;
-    } else if (tlDrag.mode === 'trim-out') {
-      const newOut = Math.max(cut.in + (1 / fps), +(tlDrag.startOut + deltaFrames).toFixed(2));
-      cut.out = newOut;
+    if (tlDrag.mode === 'trim-in' || tlDrag.mode === 'trim-out') {
+      applyBoundaryTrim(newEdit, tlDrag, deltaFrames, fps);
     } else if (tlDrag.mode === 'move') {
       const newAt = Math.max(0, +(tlDrag.startAt + deltaFrames).toFixed(2));
       const snap = tlSnapTime(newAt, tlDrag.cutIndex);
-      cut.at = snap !== null ? snap : newAt;
+      newEdit.cuts[tlDrag.cutIndex].at = snap !== null ? snap : newAt;
     }
-    // Snap right edge for trim
-    if (tlDrag.mode === 'trim-out' || tlDrag.mode === 'trim-in') {
-      const atPos = tlDrag.startAt !== null ? tlDrag.startAt : tlDrag.cursorStart;
-      const speed = cut.speed || 1;
-      const rightEdge = atPos + ((cut.out || 0) - (cut.in || 0)) / speed;
-      const snap = tlSnapTime(rightEdge, tlDrag.cutIndex);
-      if (snap !== null) {
-        const newDur = snap - atPos;
-        if (tlDrag.mode === 'trim-out') {
-          cut.out = Math.max(cut.in + 1 / fps, +(cut.in + newDur * speed).toFixed(3));
-        } else {
-          cut.in = Math.max(0, Math.min(cut.out - 1 / fps, +(cut.out - newDur * speed).toFixed(3)));
-        }
-      }
-    }
-    // Re-render timeline with new cuts
+    // Live preview: rebuild tracks from the mutated cuts so segments/rendering
+    // reflect the drag, then restore the original data.
+    syncTracksFromCuts(newEdit);
     const oldCuts = summary.cuts;
+    const oldTracks = summary.tracks;
     summary.cuts = newEdit.cuts;
+    summary.tracks = newEdit.tracks;
     buildSegments();
     summary.cuts = oldCuts;
+    summary.tracks = oldTracks;
     tlDrag.saved = false;
     e.preventDefault();
   });
@@ -2923,17 +3190,14 @@ function setupTimeline() {
     }
     // Save to server
     const newEdit = JSON.parse(JSON.stringify(summary));
-    const cut = newEdit.cuts[tlDrag.cutIndex];
-    if (!cut) { tlDrag = null; return; }
-    if (tlDrag.mode === 'trim-in') {
-      const deltaSec = (tlTimelineX(e) - tlDrag.startPx) / tlZoom;
-      cut.in = Math.max(0, +(tlDrag.startIn + deltaSec).toFixed(2));
-    } else if (tlDrag.mode === 'trim-out') {
-      const deltaSec = (tlTimelineX(e) - tlDrag.startPx) / tlZoom;
-      cut.out = Math.max(cut.in + (1 / fps), +(tlDrag.startOut + deltaSec).toFixed(2));
+    const finalDelta = (tlTimelineX(e) - tlDrag.startPx) / tlZoom;
+    const finalDeltaFrames = Math.round(finalDelta * fps) / fps;
+    if (tlDrag.mode === 'trim-in' || tlDrag.mode === 'trim-out') {
+      applyBoundaryTrim(newEdit, tlDrag, finalDeltaFrames, fps);
     } else if (tlDrag.mode === 'move') {
-      const deltaSec = (tlTimelineX(e) - tlDrag.startPx) / tlZoom;
-      cut.at = Math.max(0, +(tlDrag.startAt + deltaSec).toFixed(2));
+      const newAt = Math.max(0, +(tlDrag.startAt + finalDeltaFrames).toFixed(2));
+      const snap = tlSnapTime(newAt, tlDrag.cutIndex);
+      newEdit.cuts[tlDrag.cutIndex].at = snap !== null ? snap : newAt;
     }
     try {
       syncTracksFromCuts(newEdit);
@@ -2975,6 +3239,7 @@ function setupTimeline() {
   let dropIndicator = null;
   tlCanvas.addEventListener('dragover', (e) => {
     e.preventDefault();
+    if (!editMode) { e.dataTransfer.dropEffect = 'none'; return; }
     e.dataTransfer.dropEffect = 'copy';
     if (!dropIndicator) {
       dropIndicator = document.createElement('div');
@@ -2989,6 +3254,7 @@ function setupTimeline() {
   tlCanvas.addEventListener('drop', async (e) => {
     e.preventDefault();
     dropIndicator?.remove(); dropIndicator = null;
+    if (!requireTimelineEdit()) return;
     const assetPath = e.dataTransfer.getData('text/plain');
     if (!assetPath || !summary?.cuts) return;
     const t = tlTimeFromX(tlTimelineX(e));
@@ -3010,7 +3276,7 @@ function setupTimeline() {
 function renderTrackHeaders() {
   const headers = document.getElementById('tl-headers');
   if (!headers) return;
-  const tracks = summary?.tracks?.filter(t => t.type === 'video') || [];
+  const tracks = summary?.tracks || [];
   let html = `<div class="timeline-track-header" style="height:22px"></div>`;
   for (const t of tracks) {
     const isM = t.isMain ? ' ★' : '';
@@ -3027,6 +3293,7 @@ function renderTrackHeaders() {
       const track = summary?.tracks?.find(t => t.id === trackId);
       if (!track || track.isMain) return;
       e.preventDefault();
+      if (!editMode) return;
       const ctx = document.getElementById('ctx-menu');
       ctx.innerHTML = `
         <button id="ctx-remove-track">トラックを削除</button>
@@ -3057,11 +3324,11 @@ function renderTrackHeaders() {
 let trackHeaderCtxInitialized = false;
 
 function getTimelineTrackCount() {
-  return (summary?.tracks?.filter(t => t.type === 'video') || []).length || 1;
+  return (summary?.tracks?.length) || 1;
 }
 
 function getTrackY(trackId) {
-  const tracks = summary?.tracks?.filter(t => t.type === 'video') || [];
+  const tracks = summary?.tracks || [];
   const idx = tracks.findIndex(t => t.id === trackId);
   return idx >= 0 ? idx * TL_TRACK_HEIGHT : 0;
 }
@@ -3097,81 +3364,78 @@ function renderTimeline() {
     const y = tn * TL_TRACK_HEIGHT;
     ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(totalPx, y); ctx.stroke();
   }
-  // Draw clips for each video track
-  const videoTracks = summary?.tracks?.filter(t => t.type === 'video') || [];
-  for (const track of videoTracks) {
+  // Draw clips for each track
+  const allTracks = summary?.tracks || [];
+  for (const track of allTracks) {
     const tY = getTrackY(track.id);
     const segH = TL_TRACK_HEIGHT - 4;
     let cursor = 0;
     let cursorAcc = 0;
     for (let ci = 0; ci < track.clips.length; ci++) {
       const clip = track.clips[ci];
-      const inSec = clip.in || 0;
-      const outSec = clip.out || inSec + 1;
-      const speed = clip.speed || 1;
-      const dur = (outSec - inSec) / speed;
-      const at = clip.at;
-      // Position: if at is specified, use it; else sequential
-      let clipStart;
-      if (at !== undefined) {
-        clipStart = at;
-        cursorAcc = at;
+      if (track.type === 'video') {
+        const inSec = clip.in || 0;
+        const outSec = clip.out || inSec + 1;
+        const speed = clip.speed || 1;
+        const dur = (outSec - inSec) / speed;
+        const at = clip.at;
+        let clipStart;
+        if (at !== undefined) { clipStart = at; cursorAcc = at; }
+        else { clipStart = cursor; }
+        const sx = clipStart * tlZoom;
+        const sw = Math.max(2, dur * tlZoom);
+        const color = track.isMain ? TL_CUT_COLORS[ci % TL_CUT_COLORS.length] : '#6ab04c';
+        const grad = ctx.createLinearGradient(sx, tY, sx, tY + TL_TRACK_HEIGHT);
+        grad.addColorStop(0, color); grad.addColorStop(0.5, color); grad.addColorStop(1, '#000');
+        ctx.fillStyle = grad;
+        const rx = sx, ry = tY + 2, rw = sw, rh = segH;
+        const rn = 3;
+        ctx.beginPath(); ctx.moveTo(rx + rn, ry); ctx.lineTo(rx + rw - rn, ry); ctx.quadraticCurveTo(rx + rw, ry, rx + rw, ry + rn);
+        ctx.lineTo(rx + rw, ry + rh - rn); ctx.quadraticCurveTo(rx + rw, ry + rh, rx + rw - rn, ry + rh);
+        ctx.lineTo(rx + rn, ry + rh); ctx.quadraticCurveTo(rx, ry + rh, rx, ry + rh - rn);
+        ctx.lineTo(rx, ry + rn); ctx.quadraticCurveTo(rx, ry, rx + rn, ry);
+        ctx.fill();
+        if (track.isMain && sw > TL_HANDLE_PX * 3) {
+          ctx.fillStyle = 'rgba(0,0,0,0.25)';
+          ctx.fillRect(sx, tY + 2, TL_HANDLE_PX, segH);
+          ctx.fillRect(sx + sw - TL_HANDLE_PX, tY + 2, TL_HANDLE_PX, segH);
+          ctx.fillStyle = 'rgba(255,255,255,0.3)';
+          for (let g = 0; g < 3; g++) { const gh = tY + 2 + 5 + g * 6; ctx.fillRect(sx + 2, gh, 4, 2); ctx.fillRect(sx + sw - 6, gh, 4, 2); }
+        }
+        if (sw > 30) {
+          ctx.fillStyle = '#fff'; ctx.font = '10px system-ui, sans-serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+          ctx.fillText(track.isMain ? `#${ci + 1}` : (clip.id ? clip.id.slice(0, 8) : ''), sx + sw / 2, tY + TL_TRACK_HEIGHT / 2);
+        }
+        if (track.isMain && sw > 80) {
+          ctx.fillStyle = 'rgba(255,255,255,0.4)'; ctx.font = '8px system-ui, sans-serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'bottom';
+          const fmt = (s) => { const m = Math.floor(s / 60); return `${m}:${String(Math.floor(s % 60)).padStart(2, '0')}.${String(Math.floor((s % 1) * 100)).padStart(2, '0')}`; };
+          ctx.fillText(`${fmt(inSec)} → ${fmt(outSec)}`, sx + sw / 2, tY + 1);
+        }
+        cursor = clipStart + dur;
+        if (at === undefined) cursorAcc = cursor;
       } else {
-        clipStart = cursor;
-      }
-      // Gap if not contiguous
-      if (ci > 0 && at !== undefined) {
-        // gap is handled by at positioning
-      }
-      const segIndex = track.isMain ? ci : -1;
-      const sx = clipStart * tlZoom;
-      const sw = Math.max(2, dur * tlZoom);
-      const color = track.isMain ? TL_CUT_COLORS[ci % TL_CUT_COLORS.length] : '#6ab04c';
-      // Draw clip body
-      const grad = ctx.createLinearGradient(sx, tY, sx, tY + TL_TRACK_HEIGHT);
-      grad.addColorStop(0, color);
-      grad.addColorStop(0.5, color);
-      grad.addColorStop(1, '#000');
-      ctx.fillStyle = grad;
-      const rx = sx, ry = tY + 2, rw = sw, rh = segH;
-      const r = 3;
-      ctx.beginPath();
-      ctx.moveTo(rx + r, ry); ctx.lineTo(rx + rw - r, ry); ctx.quadraticCurveTo(rx + rw, ry, rx + rw, ry + r);
-      ctx.lineTo(rx + rw, ry + rh - r); ctx.quadraticCurveTo(rx + rw, ry + rh, rx + rw - r, ry + rh);
-      ctx.lineTo(rx + r, ry + rh); ctx.quadraticCurveTo(rx, ry + rh, rx, ry + rh - r);
-      ctx.lineTo(rx, ry + r); ctx.quadraticCurveTo(rx, ry, rx + r, ry);
-      ctx.fill();
-      // Handles on main track
-      if (track.isMain && sw > TL_HANDLE_PX * 3) {
-        ctx.fillStyle = 'rgba(0,0,0,0.25)';
-        ctx.fillRect(sx, tY + 2, TL_HANDLE_PX, segH);
-        ctx.fillRect(sx + sw - TL_HANDLE_PX, tY + 2, TL_HANDLE_PX, segH);
-        ctx.fillStyle = 'rgba(255,255,255,0.3)';
-        for (let g = 0; g < 3; g++) {
-          const gh = tY + 2 + 5 + g * 6;
-          ctx.fillRect(sx + 2, gh, 4, 2);
-          ctx.fillRect(sx + sw - 6, gh, 4, 2);
+        // Audio / narration / sfx tracks
+        const dur = clip.out !== undefined ? (clip.out - (clip.in || 0)) / (clip.speed || 1) : (clip.duration || totalDuration);
+        const at = clip.at ?? 0;
+        const sx = at * tlZoom;
+        const sw = Math.max(2, dur * tlZoom);
+        const ac = track.type === 'narration' ? '#ffd94a' : track.type === 'sfx' ? '#ff798c' : '#4da3ff';
+        ctx.fillStyle = ac;
+        ctx.globalAlpha = 0.35;
+        const rx = sx, ry = tY + 2, rw = sw, rh = segH;
+        const rr = 3;
+        ctx.beginPath(); ctx.moveTo(rx + rr, ry); ctx.lineTo(rx + rw - rr, ry); ctx.quadraticCurveTo(rx + rw, ry, rx + rw, ry + rr);
+        ctx.lineTo(rx + rw, ry + rh - rr); ctx.quadraticCurveTo(rx + rw, ry + rh, rx + rw - rr, ry + rh);
+        ctx.lineTo(rx + rr, ry + rh); ctx.quadraticCurveTo(rx, ry + rh, rx, ry + rh - rr);
+        ctx.lineTo(rx, ry + rr); ctx.quadraticCurveTo(rx, ry, rx + rr, ry);
+        ctx.fill();
+        ctx.globalAlpha = 1;
+        if (sw > 20) {
+          ctx.fillStyle = ac; ctx.font = '9px system-ui, sans-serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+          const label = clip.src ? clip.src.split('/').pop() : '';
+          ctx.fillText(label, sx + sw / 2, tY + TL_TRACK_HEIGHT / 2);
         }
       }
-      // Label
-      if (sw > 30) {
-        ctx.fillStyle = '#fff';
-        ctx.font = '10px system-ui, sans-serif';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        const label = track.isMain ? `#${ci + 1}` : (clip.id ? clip.id.slice(0, 8) : '');
-        ctx.fillText(label, sx + sw / 2, tY + TL_TRACK_HEIGHT / 2);
-      }
-      if (track.isMain && sw > 80) {
-        ctx.fillStyle = 'rgba(255,255,255,0.4)';
-        ctx.font = '8px system-ui, sans-serif';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'bottom';
-        const fmt = (sec) => { const m = Math.floor(sec / 60); return `${m}:${String(Math.floor(sec % 60)).padStart(2, '0')}.${String(Math.floor((sec % 1) * 100)).padStart(2, '0')}`; };
-        ctx.fillText(`${fmt(inSec)} → ${fmt(outSec)}`, sx + sw / 2, tY + 1);
-      }
-      cursor = clipStart + dur;
-      if (at === undefined) cursorAcc = cursor;
     }
   }
   // Ruler
@@ -3232,8 +3496,9 @@ seekTo = function(t) {
 const origBuildSegments = buildSegments;
 buildSegments = function() {
   origBuildSegments();
+  setupSegmentVideos();
   if (totalDuration > 0) {
-    tlZoom = computeNaturalZoom();
+    if (!tlDrag) tlZoom = computeNaturalZoom();
     renderTimeline();
   }
 };
@@ -3242,17 +3507,17 @@ buildSegments = function() {
 const outputBtn = document.getElementById('output-preview-btn');
 if (isOutputMode) {
   document.title = 'AKARI Video Preview (出力)';
+}
+if (VIEWER_MODE || isOutputMode) {
   outputBtn.hidden = true;
+}
+if (VIEWER_MODE) {
   reviewRecordBtn.hidden = true;
-} else {
-  outputBtn.hidden = false;
-  outputBtn.addEventListener('click', () => {
-    window.open('/?mode=output', 'akari-output-preview', 'width=960,height=600');
-  });
 }
 
 init();
 connectWs();
+setupAssetPreview();
 setupAssetBrowser();
 setupTimeline();
 loadAssets();
@@ -3264,7 +3529,9 @@ window.__test = {
   get outputTime() { return outputTime; },
   get totalDuration() { return totalDuration; },
   get isPlaying() { return isPlaying; },
+  get assetPreview() { return assetPreview; },
   seekTo, getActiveSegment, tlSplitCut, tlDeleteCut,
   addTrack, removeTrack, renderTrackHeaders,
   normalizeTracks, syncTracksFromCuts,
+  enterAssetPreview, exitAssetPreview,
 };

--- a/packages/preview-server/public/index.html
+++ b/packages/preview-server/public/index.html
@@ -11,9 +11,9 @@
 * { box-sizing: border-box; }
 html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; background: #141414; color: #eee; }
 
-.app-root { width: 100%; height: 100%; display: grid; grid-template-rows: 1fr auto auto; min-height: 0; }
+.app-root { width: 100%; height: 100%; display: grid; grid-template-rows: 1fr 4px var(--pane-bottom-height, 220px); min-height: 0; }
 
-.main-panes { min-height: 0; display: grid; grid-template-columns: 260px 1fr; overflow: hidden; }
+.main-panes { min-height: 0; display: grid; grid-template-columns: var(--pane-left-width, 260px) 4px 1fr; overflow: hidden; }
 
 .pane { display: flex; flex-direction: column; min-height: 0; }
 .pane-header { display: flex; align-items: center; gap: 8px; padding: 6px 10px; background: #1a1a1a; border-bottom: 1px solid #303030; font-size: 12px; font-weight: 600; color: #aaa; flex-shrink: 0; }
@@ -31,6 +31,9 @@ html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; background:
 .asset-item:hover { background: #222; }
 .asset-item:active { background: #2a2a2a; }
 .asset-item.is-active { background: #1a3050; }
+.asset-item.selected { background: #123a63; box-shadow: inset 3px 0 0 #4da3ff; }
+.asset-item.selected::after { content: '▶'; margin-left: auto; color: #4da3ff; font-size: 10px; }
+.asset-item.selected .asset-name { color: #fff; }
 .asset-icon { flex-shrink: 0; width: 28px; height: 28px; border-radius: 3px; background: #222; display: grid; place-items: center; font-size: 14px; }
 .asset-icon.video { color: #4da3ff; }
 .asset-icon.audio { color: #ffd94a; }
@@ -80,9 +83,30 @@ html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; background:
 #zoom-minimap[hidden] { display: none; }
 #zoom-minimap video { width: 100%; height: 100%; object-fit: contain; }
 #zoom-minimap-viewport { position: absolute; border: 1px solid #ff0; background: rgba(255,255,0,0.08); pointer-events: none; }
-.message-card { position: absolute; inset: 0; z-index: 10; display: grid; gap: 16px; place-items: center; padding: 32px; background: #111; }
-.message-card[hidden] { display: none; }
-.message-card p { max-width: 520px; margin: 0; color: #e5e5e5; font-size: 15px; line-height: 1.7; text-align: center; }
+#toast { position: absolute; left: 50%; bottom: 14px; transform: translateX(-50%); z-index: 80; max-width: 80%; padding: 6px 14px; background: rgba(0,0,0,0.75); border: 1px solid #404040; border-radius: 4px; color: #eee; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; pointer-events: none; }
+#toast[hidden] { display: none; }
+#toast.show { animation: toast-in .12s ease-out; }
+@keyframes toast-in { from { opacity: 0; transform: translate(-50%, 4px); } to { opacity: 1; transform: translate(-50%, 0); } }
+
+/* Asset preview */
+#asset-preview { position: absolute; inset: 0; z-index: 30; background: #000; display: grid; place-items: center; padding: 16px; }
+#asset-preview[hidden] { display: none; }
+#asset-preview img, #asset-preview video { max-width: 100%; max-height: 100%; object-fit: contain; }
+#asset-preview video { width: 100%; height: 100%; }
+#asset-preview-note { display: grid; place-items: center; gap: 16px; }
+#asset-preview-note[hidden] { display: none; }
+#asset-preview-note .note-symbol { font-size: 90px; color: #3a3a3a; line-height: 1; user-select: none; transition: color .15s; }
+#asset-preview-note .note-eq { display: flex; gap: 5px; align-items: flex-end; height: 34px; }
+#asset-preview-note .note-eq span { width: 6px; height: 6px; border-radius: 2px; background: #3a3a3a; }
+#asset-preview-note.playing .note-symbol { color: #4da3ff; animation: note-pulse 1.2s ease-in-out infinite; }
+#asset-preview-note.playing .note-eq span { background: #4da3ff; animation: eq-bounce 1s ease-in-out infinite; }
+#asset-preview-note.playing .note-eq span:nth-child(2) { animation-delay: .15s; }
+#asset-preview-note.playing .note-eq span:nth-child(3) { animation-delay: .3s; }
+#asset-preview-note.playing .note-eq span:nth-child(4) { animation-delay: .45s; }
+#asset-preview-note.playing .note-eq span:nth-child(5) { animation-delay: .6s; }
+@keyframes note-pulse { 0%,100% { transform: scale(1); } 50% { transform: scale(1.15); } }
+@keyframes eq-bounce { 0%,100% { height: 6px; } 50% { height: 34px; } }
+#asset-preview-label { position: absolute; top: 10px; left: 50%; transform: translateX(-50%); max-width: 90%; background: rgba(0,0,0,0.65); border: 1px solid #404040; color: #ddd; font-size: 12px; padding: 3px 12px; border-radius: 3px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; pointer-events: none; }
 
 /* Timeline pane */
 .pane-bottom { border-top: 1px solid #303030; background: #1a1a1a; }
@@ -102,13 +126,6 @@ html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; background:
 #tl-ruler-canvas { display: block; width: 100%; height: 100%; }
 
 /* Transport */
-.transport-waveform { border-top: 1px solid #303030; background: #1e1e1e; padding: 0 12px; }
-.transport-waveform[hidden] { display: none; }
-.waveform-track { position: relative; height: 22px; display: flex; align-items: center; border-bottom: 1px solid #282828; cursor: pointer; touch-action: none; }
-.waveform-track-label { position: absolute; left: 4px; z-index: 2; color: #666; font-size: 8px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; pointer-events: none; text-shadow: 0 0 3px #000; }
-.waveform-track-visual { position: absolute; inset: 0; }
-.waveform-track-canvas, #waveform-canvas { display: block; width: 100%; height: 100%; }
-.transport-waveform-playhead { position: absolute; top: 0; bottom: 0; left: 0; width: 1px; background: rgba(255, 255, 255, 0.7); pointer-events: none; z-index: 1; }
 .transport-seek { display: flex; width: 100%; position: relative; background:#1e1e1e; }
 .transport-seek input { width: 100%; }
 .pane-center .transport-seek { border-top: none; }
@@ -125,21 +142,24 @@ html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; background:
 .icon-button:disabled { opacity: 0.45; cursor: default; }
 .icon-button svg { width: 16px; height: 16px; fill: currentColor; stroke: currentColor; }
 #time-label { min-width: 100px; color: #d0d0d0; font-variant-numeric: tabular-nums; text-align: left; font-size: 13px; }
-.popup { position: absolute; right: 0; bottom: calc(100% + 8px); z-index: 20; width: 224px; border: 1px solid #505050; border-radius: 6px; padding: 10px; background: #202020; box-shadow: 0 4px 16px rgba(0,0,0,0.45); }
+.popup { position: absolute; right: 0; bottom: calc(100% + 8px); z-index: 60; width: 224px; border: 1px solid #505050; border-radius: 6px; padding: 10px; background: #202020; box-shadow: 0 4px 16px rgba(0,0,0,0.45); }
 .popup[hidden] { display: none; }
 .popup-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; color: #d8d8d8; font-size: 12px; }
 #zoom-value { color: #fff; font-variant-numeric: tabular-nums; }
 input[type=range] { width: 100%; }
 .zoom-presets { display: grid; grid-template-columns: repeat(4, 32px); justify-content: space-between; gap: 5px; margin-top: 8px; }
 .zoom-preset { width: 32px; height: 32px; border: 1px solid #505050; border-radius: 4px; padding: 0; background: #303030; color: #fff; font-size: 10px; cursor: pointer; }
-.transform-popup { position: absolute; left: 0; bottom: calc(100% + 8px); z-index: 20; width: 200px; border: 1px solid #505050; border-radius: 6px; padding: 10px; background: #202020; box-shadow: 0 4px 16px rgba(0,0,0,0.45); }
+.zoom-fit { width: 100%; margin-top: 8px; padding: 5px 0; border: 1px solid #505050; border-radius: 4px; background: #303030; color: #ccc; font-size: 11px; cursor: pointer; }
+.zoom-fit:hover { background: #404040; color: #fff; }
+.zoom-fit.is-active { border-color: #4da3ff; color: #4da3ff; }
+.transform-popup { position: absolute; left: 0; bottom: calc(100% + 8px); z-index: 60; width: 200px; border: 1px solid #505050; border-radius: 6px; padding: 10px; background: #202020; box-shadow: 0 4px 16px rgba(0,0,0,0.45); }
 .transform-popup[hidden] { display: none; }
 .transform-row { display: flex; align-items: center; gap: 6px; margin-bottom: 4px; }
 .transform-row label { color: #aaa; font-size: 11px; width: 32px; }
 .transform-row input { flex: 1; background: #303030; border: 1px solid #505050; border-radius: 3px; color: #fff; font-size: 12px; padding: 2px 4px; width: 0; }
 .transform-row input:focus { border-color: #7af; outline: none; }
 #selection-label { font-size: 11px; color: #888; }
-    .indicator-popup { position: absolute; left: 0; bottom: calc(100% + 8px); z-index: 20; width: 260px; border: 1px solid #505050; border-radius: 6px; padding: 10px; background: #202020; box-shadow: 0 4px 16px rgba(0,0,0,0.45); }
+    .indicator-popup { position: absolute; left: 0; bottom: calc(100% + 8px); z-index: 60; width: 260px; border: 1px solid #505050; border-radius: 6px; padding: 10px; background: #202020; box-shadow: 0 4px 16px rgba(0,0,0,0.45); }
     .indicator-popup[hidden] { display: none; }
     #ctx-menu { position: fixed; z-index: 100; min-width: 160px; border: 1px solid #505050; border-radius: 6px; padding: 4px 0; background: #202020; box-shadow: 0 4px 16px rgba(0,0,0,0.5); }
     #ctx-menu[hidden] { display: none; }
@@ -162,9 +182,11 @@ input[type=range] { width: 100%; }
 #loading-indicator > div:first-child { width:32px;height:32px;border:3px solid #505050;border-top-color:#4da3ff;border-radius:50%;animation:spin 0.8s linear infinite;margin:0 auto 8px; }
 #loading-indicator > div:last-child { color:#888;font-size:12px; }
 
-/* Resize handle */
+/* Resize handles */
 .pane-left-resize { flex-shrink: 0; width: 4px; cursor: col-resize; background: transparent; transition: background 0.2s; }
-.pane-left-resize:hover { background: #4da3ff; }
+.pane-left-resize:hover, .pane-left-resize.is-dragging { background: #4da3ff; }
+.pane-bottom-resize { height: 4px; cursor: row-resize; background: transparent; transition: background 0.2s; }
+.pane-bottom-resize:hover, .pane-bottom-resize.is-dragging { background: #4da3ff; }
 /* Add-track dialog */
 #add-track-dialog { position: fixed; inset: 0; z-index: 10000; background: rgba(0,0,0,0.6); display: grid; place-items: center; }
 #add-track-dialog[hidden] { display: none; }
@@ -200,13 +222,14 @@ input[type=range] { width: 100%; }
       <input class="asset-search" id="asset-search" type="search" placeholder="素材を検索..." spellcheck="false">
       <div class="pane-content" id="asset-list"></div>
     </aside>
+    <div class="pane-left-resize"></div>
 
     <!-- Center: Preview -->
     <div class="pane pane-center" style="display:flex;flex-direction:column">
       <div class="preview-area" style="flex:1;min-height:0">
         <div id="preview-wrapper">
           <div id="zoom-layer">
-            <video id="preview-video" preload="auto"></video>
+            <video id="preview-video" preload="auto" muted></video>
             <div id="layer-container"></div>
             <div id="overlay-stage">
               <div id="pen-layer"><canvas id="pen-canvas"></canvas></div>
@@ -222,9 +245,19 @@ input[type=range] { width: 100%; }
               </div>
             </div>
           </div>
+          <div id="asset-preview" hidden>
+            <img id="asset-preview-image" alt="">
+            <video id="asset-preview-video" preload="auto"></video>
+            <audio id="asset-preview-audio" preload="auto"></audio>
+            <div id="asset-preview-note" hidden>
+              <div class="note-symbol">♫</div>
+              <div class="note-eq"><span></span><span></span><span></span><span></span><span></span></div>
+            </div>
+            <div id="asset-preview-label"></div>
+          </div>
           <div id="loading-indicator"><div></div><div>読み込み中...</div></div>
           <div id="zoom-minimap" hidden><video id="minimap-video" preload="auto"></video><div id="zoom-minimap-viewport"></div></div>
-          <div id="preview-message" class="message-card" hidden role="status"><p id="preview-message-text"></p></div>
+          <div id="toast" hidden role="status"></div>
         </div>
       </div>
       <div class="transport-seek" style="padding:3px 12px">
@@ -237,7 +270,6 @@ input[type=range] { width: 100%; }
       </div>
       <div class="transport-controls">
         <div class="transport-left">
-          <button id="waveform-toggle" class="icon-button" type="button" aria-label="波形" title="波形" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h2m2-4v8m3-12v16m3-13v10m3-7v4m3-2h2" fill="none" stroke-width="2" stroke-linecap="round"/></svg></button>
           <span id="time-label">0:00 / 0:00</span>
           <button id="edit-toggle" class="icon-button" type="button" aria-label="編集" title="編集" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a1.0 1.0 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg></button>
           <button id="indicator-toggle" class="icon-button" type="button" aria-label="指標" title="指標" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg></button>
@@ -268,13 +300,14 @@ input[type=range] { width: 100%; }
             <div><label style="color:#aaa;font-size:11px">ゾーン</label><select id="caption-zone-select" style="width:100%;background:#303030;color:#fff;border:1px solid #505050;border-radius:3px;padding:2px 4px;font-size:12px"></select></div>
             <div style="display:flex;gap:6px;margin-top:6px"><label style="color:#aaa;font-size:11px;flex:1">色 <input id="caption-color-input" type="color" style="width:100%;background:#303030;border:1px solid #505050;border-radius:3px;height:24px"></label><label style="color:#aaa;font-size:11px;flex:1">サイズ <input id="caption-size-input" type="number" min="12" max="120" step="1" style="width:100%;background:#303030;color:#fff;border:1px solid #505050;border-radius:3px;padding:2px 4px;font-size:12px"></label></div>
           </div>
-          <button id="output-preview-btn" class="icon-button" type="button" aria-label="出力プレビュー" title="出力プレビュー" hidden><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm0 16H5V5h14v14zM7 10h2v7H7zm4-3h2v10h-2zm4 5h2v5h-2z"/></svg></button>
+          <button id="output-preview-btn" class="icon-button" type="button" aria-label="出力プレビュー" title="出力プレビュー"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm0 16H5V5h14v14zM7 10h2v7H7zm4-3h2v10h-2zm4 5h2v5h-2z"/></svg></button>
           <button id="review-record-btn" class="icon-button" type="button" aria-label="レビュー録音" title="レビュー録音" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="6" fill="currentColor"/></svg></button>
           <span id="review-timer" style="display:none;color:#ff4444;font-size:12px;font-variant-numeric:tabular-nums;min-width:70px;text-align:center">0:00</span>
           <div id="zoom-popup" class="popup" hidden>
             <div class="popup-header"><span>ズーム</span><span id="zoom-value">100%</span></div>
             <input id="zoom-slider" type="range" min="0" max="1" step="0.001" aria-label="ズーム倍率">
             <div class="zoom-presets"><button class="zoom-preset" type="button" data-zoom="0.5">50%</button><button class="zoom-preset" type="button" data-zoom="1">100%</button><button class="zoom-preset" type="button" data-zoom="2">200%</button><button class="zoom-preset" type="button" data-zoom="4">400%</button></div>
+            <button id="zoom-fit" class="zoom-fit" type="button">画面に合わせる</button>
           </div>
         </div>
       </div>
@@ -282,6 +315,7 @@ input[type=range] { width: 100%; }
   </div>
 
   <!-- Bottom: Timeline -->
+  <div class="pane-bottom-resize"></div>
   <div class="pane pane-bottom" id="timeline-pane">
     <div class="pane-header">
       <span>タイムライン</span>
@@ -312,37 +346,6 @@ input[type=range] { width: 100%; }
       <button id="ctx-move-down">下へ移動</button>
     </div>
     <div id="asset-ctx-menu" hidden></div>
-    </div>
-  </div>
-
-  <div class="transport-waveform" hidden>
-    <div class="waveform-track">
-      <span class="waveform-track-label">Video</span>
-      <div class="waveform-track-visual">
-        <canvas id="waveform-canvas" aria-label="音声波形"></canvas>
-        <div class="transport-waveform-playhead" aria-hidden="true"></div>
-      </div>
-    </div>
-    <div class="waveform-track" id="waveform-track-bgm" hidden>
-      <span class="waveform-track-label">BGM</span>
-      <div class="waveform-track-visual">
-        <canvas class="waveform-track-canvas" data-track="bgm"></canvas>
-        <div class="transport-waveform-playhead" aria-hidden="true"></div>
-      </div>
-    </div>
-    <div class="waveform-track" id="waveform-track-narration" hidden>
-      <span class="waveform-track-label">Nar</span>
-      <div class="waveform-track-visual">
-        <canvas class="waveform-track-canvas" data-track="narration"></canvas>
-        <div class="transport-waveform-playhead" aria-hidden="true"></div>
-      </div>
-    </div>
-    <div class="waveform-track" id="waveform-track-sfx" hidden>
-      <span class="waveform-track-label">SFX</span>
-      <div class="waveform-track-visual">
-        <canvas class="waveform-track-canvas" data-track="sfx"></canvas>
-        <div class="transport-waveform-playhead" aria-hidden="true"></div>
-      </div>
     </div>
   </div>
 </div>

--- a/packages/preview-server/public/index.html
+++ b/packages/preview-server/public/index.html
@@ -320,6 +320,8 @@ input[type=range] { width: 100%; }
       <tr><td>← →</td><td>1フレーム戻る/進む</td></tr>
       <tr><td>↑ ↓</td><td>10秒戻る/進む</td></tr>
       <tr><td>, .</td><td>前/次のカット境界へ</td></tr>
+      <tr><td>S</td><td>再生位置でカットを分割</td></tr>
+      <tr><td>Del / ⌫</td><td>再生位置のカットを削除</td></tr>
       <tr><td>Home / End</td><td>先頭/末尾へ</td></tr>
       <tr><td>?</td><td>このヘルプを表示/非表示</td></tr>
       <tr><td>Escape</td><td>選択解除 / ポップアップを閉じる</td></tr>

--- a/packages/preview-server/public/index.html
+++ b/packages/preview-server/public/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>AKARI Video Preview</title>
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><rect width='16' height='16' rx='3' fill='%23e44'/><text x='8' y='12' text-anchor='middle' font-size='11' font-weight='bold' fill='%23fff'>A</text></svg>">
 <style>
 :root { color-scheme: dark; font-family: "Noto Sans JP", system-ui, sans-serif; }
 @keyframes spin { to { transform: rotate(360deg); } }
@@ -91,8 +92,9 @@ html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; background:
 .tl-btn:hover { background: #333; border-color: #555; }
 #tl-zoom-label { font-size: 10px; color: #666; min-width: 32px; text-align: center; }
 .timeline-body { display: flex; flex: 1; min-height: 0; overflow: hidden; }
-.timeline-headers { flex-shrink: 0; width: 70px; border-right: 1px solid #303030; background: #161616; }
-.timeline-track-header { height: 28px; display: flex; align-items: center; padding: 0 8px; font-size: 9px; color: #666; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; border-bottom: 1px solid #282828; }
+.timeline-headers { flex-shrink: 0; width: 70px; border-right: 1px solid #303030; background: #161616; display:flex;flex-direction:column; }
+.timeline-track-header { height: 28px; display: flex; align-items: center; padding: 0 8px; font-size: 9px; color: #666; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; border-bottom: 1px solid #282828; flex-shrink:0;cursor:pointer; }
+.timeline-track-header:hover { color: #aaa; background: #1e1e1e; }
 .timeline-canvas-wrap { flex: 1; min-width: 0; overflow-x: auto; overflow-y: hidden; position: relative; }
 #timeline-canvas { display: block; height: 100%; }
 .timeline-playhead { position: absolute; top: 0; bottom: 0; width: 1px; background: #fff; pointer-events: none; z-index: 5; }
@@ -100,16 +102,17 @@ html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; background:
 #tl-ruler-canvas { display: block; width: 100%; height: 100%; }
 
 /* Transport */
-.transport { display: grid; gap: 6px; padding: 6px 12px 8px; border-top: 1px solid #303030; background: #1e1e1e; }
-.transport-waveform { width: 100%; overflow: hidden; }
+.transport-waveform { border-top: 1px solid #303030; background: #1e1e1e; padding: 0 12px; }
 .transport-waveform[hidden] { display: none; }
 .waveform-track { position: relative; height: 22px; display: flex; align-items: center; border-bottom: 1px solid #282828; cursor: pointer; touch-action: none; }
 .waveform-track-label { position: absolute; left: 4px; z-index: 2; color: #666; font-size: 8px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; pointer-events: none; text-shadow: 0 0 3px #000; }
 .waveform-track-visual { position: absolute; inset: 0; }
 .waveform-track-canvas, #waveform-canvas { display: block; width: 100%; height: 100%; }
 .transport-waveform-playhead { position: absolute; top: 0; bottom: 0; left: 0; width: 1px; background: rgba(255, 255, 255, 0.7); pointer-events: none; z-index: 1; }
-.transport-seek { display: flex; width: 100%; position: relative; }
+.transport-seek { display: flex; width: 100%; position: relative; background:#1e1e1e; }
 .transport-seek input { width: 100%; }
+.pane-center .transport-seek { border-top: none; }
+.pane-center .transport-controls { border-top: 1px solid #303030; background: #1e1e1e; padding: 4px 12px 6px; gap: 6px; }
 .transport-controls { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; min-width: 0; }
 .transport-left, .transport-center, .transport-right { display: flex; align-items: center; gap: 6px; }
 .transport-left, .transport-center { position: relative; min-width: 0; }
@@ -136,8 +139,19 @@ input[type=range] { width: 100%; }
 .transform-row input { flex: 1; background: #303030; border: 1px solid #505050; border-radius: 3px; color: #fff; font-size: 12px; padding: 2px 4px; width: 0; }
 .transform-row input:focus { border-color: #7af; outline: none; }
 #selection-label { font-size: 11px; color: #888; }
-.indicator-popup { position: absolute; left: 0; bottom: calc(100% + 8px); z-index: 20; width: 260px; border: 1px solid #505050; border-radius: 6px; padding: 10px; background: #202020; box-shadow: 0 4px 16px rgba(0,0,0,0.45); }
-.indicator-popup[hidden] { display: none; }
+    .indicator-popup { position: absolute; left: 0; bottom: calc(100% + 8px); z-index: 20; width: 260px; border: 1px solid #505050; border-radius: 6px; padding: 10px; background: #202020; box-shadow: 0 4px 16px rgba(0,0,0,0.45); }
+    .indicator-popup[hidden] { display: none; }
+    #ctx-menu { position: fixed; z-index: 100; min-width: 160px; border: 1px solid #505050; border-radius: 6px; padding: 4px 0; background: #202020; box-shadow: 0 4px 16px rgba(0,0,0,0.5); }
+    #ctx-menu[hidden] { display: none; }
+    #ctx-menu button { display: block; width: 100%; padding: 6px 14px; border: none; background: transparent; color: #ccc; font-size: 12px; text-align: left; cursor: pointer; }
+    #ctx-menu button:hover { background: #333; color: #fff; }
+    #ctx-menu button:disabled { color: #555; cursor: default; }
+    #ctx-menu hr { margin: 4px 8px; border: none; border-top: 1px solid #404040; }
+    #asset-ctx-menu { position: fixed; z-index: 100; min-width: 180px; border: 1px solid #505050; border-radius: 6px; padding: 4px 0; background: #202020; box-shadow: 0 4px 16px rgba(0,0,0,0.5); }
+    #asset-ctx-menu[hidden] { display: none; }
+    #asset-ctx-menu button { display: block; width: 100%; padding: 6px 14px; border: none; background: transparent; color: #ccc; font-size: 12px; text-align: left; cursor: pointer; }
+    #asset-ctx-menu button:hover { background: #333; color: #fff; }
+    #asset-ctx-menu .ctx-section-title { padding: 4px 14px 2px; color: #777; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; }
 .indicator-item { display: flex; gap: 6px; margin-bottom: 3px; font-size: 12px; color: #ccc; }
 .indicator-item .key { color: #8af; min-width: 100px; }
 .indicator-item .val { color: #aaa; }
@@ -151,6 +165,22 @@ input[type=range] { width: 100%; }
 /* Resize handle */
 .pane-left-resize { flex-shrink: 0; width: 4px; cursor: col-resize; background: transparent; transition: background 0.2s; }
 .pane-left-resize:hover { background: #4da3ff; }
+/* Add-track dialog */
+#add-track-dialog { position: fixed; inset: 0; z-index: 10000; background: rgba(0,0,0,0.6); display: grid; place-items: center; }
+#add-track-dialog[hidden] { display: none; }
+#add-track-dialog-inner { background: #202020; border: 1px solid #505050; border-radius: 8px; padding: 20px 24px; min-width: 320px; box-shadow: 0 8px 32px rgba(0,0,0,0.6); }
+#add-track-dialog-inner h3 { margin: 0 0 14px; font-size: 15px; color: #eee; }
+#add-track-dialog-inner .field { margin-bottom: 12px; }
+#add-track-dialog-inner .field label { display: block; font-size: 11px; color: #888; margin-bottom: 3px; }
+#add-track-dialog-inner .field select,
+#add-track-dialog-inner .field input { width: 100%; padding: 6px 8px; border: 1px solid #505050; border-radius: 4px; background: #181818; color: #eee; font-size: 13px; }
+#add-track-dialog-inner .field select:disabled { opacity: 0.5; }
+#add-track-dialog-inner .field input::placeholder { color: #555; }
+#add-track-dialog-inner .btns { display: flex; gap: 8px; justify-content: flex-end; margin-top: 16px; }
+#add-track-dialog-inner .btns button { padding: 6px 16px; border: 1px solid #505050; border-radius: 4px; background: #303030; color: #ccc; font-size: 12px; cursor: pointer; }
+#add-track-dialog-inner .btns button:hover { background: #404040; color: #fff; }
+#add-track-dialog-inner .btns .primary { background: #4da3ff; border-color: #4da3ff; color: #fff; }
+#add-track-dialog-inner .btns .primary:hover { background: #3b8be0; }
 </style>
 </head>
 <body>
@@ -172,8 +202,8 @@ input[type=range] { width: 100%; }
     </aside>
 
     <!-- Center: Preview -->
-    <div class="pane pane-center">
-      <div class="preview-area">
+    <div class="pane pane-center" style="display:flex;flex-direction:column">
+      <div class="preview-area" style="flex:1;min-height:0">
         <div id="preview-wrapper">
           <div id="zoom-layer">
             <video id="preview-video" preload="auto"></video>
@@ -197,6 +227,57 @@ input[type=range] { width: 100%; }
           <div id="preview-message" class="message-card" hidden role="status"><p id="preview-message-text"></p></div>
         </div>
       </div>
+      <div class="transport-seek" style="padding:3px 12px">
+        <div id="seek-visual" style="position:absolute;inset:0;display:flex;pointer-events:none;border-radius:3px;overflow:hidden;opacity:0.35"></div>
+        <input id="seek" type="range" min="0" max="0" step="0.001" value="0" aria-label="再生位置">
+        <div id="cut-info-popup" class="popup" style="left:0;right:auto;width:280px" hidden>
+          <div class="popup-header"><span>カット情報</span></div>
+          <div id="cut-info-content" style="font-size:12px;color:#ccc;line-height:1.6"></div>
+        </div>
+      </div>
+      <div class="transport-controls">
+        <div class="transport-left">
+          <button id="waveform-toggle" class="icon-button" type="button" aria-label="波形" title="波形" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h2m2-4v8m3-12v16m3-13v10m3-7v4m3-2h2" fill="none" stroke-width="2" stroke-linecap="round"/></svg></button>
+          <span id="time-label">0:00 / 0:00</span>
+          <button id="edit-toggle" class="icon-button" type="button" aria-label="編集" title="編集" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a1.0 1.0 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg></button>
+          <button id="indicator-toggle" class="icon-button" type="button" aria-label="指標" title="指標" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg></button>
+          <span id="selection-label"></span>
+          <div id="indicator-popup" class="indicator-popup" hidden></div>
+        </div>
+        <div class="transport-center">
+          <button id="frame-back" class="icon-button" type="button" aria-label="先頭" title="先頭"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5h2v14H4zm4 7l9-7v14z"/></svg></button>
+          <button id="skip-back" class="icon-button" type="button" aria-label="10秒戻る" title="10秒戻る"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 5v14l-7-7 7-7zM10 5v14l-7-7 7-7z"/></svg></button>
+          <button id="play-toggle" class="icon-button" type="button" aria-label="再生" title="再生"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></button>
+          <button id="skip-forward" class="icon-button" type="button" aria-label="10秒進む" title="10秒進む"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 5v14l7-7-7-7zM14 5v14l7-7-7-7z"/></svg></button>
+          <button id="frame-forward" class="icon-button" type="button" aria-label="末尾" title="末尾"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 5h2v14h-2zm-4 7l-9-7v14z"/></svg></button>
+        </div>
+        <div class="transport-right">
+          <div class="transform-popup" id="transform-popup" hidden>
+            <div class="popup-header"><span>トランスフォーム</span></div>
+            <div class="transform-row"><label>X</label><input id="tx" type="number" step="1"></div>
+            <div class="transform-row"><label>Y</label><input id="ty" type="number" step="1"></div>
+            <div class="transform-row"><label>拡大</label><input id="ts" type="number" step="0.01" min="0.01"></div>
+            <div class="transform-row"><label>回転</label><input id="tr" type="number" step="1"></div>
+          </div>
+          <button id="zoom-toggle" class="icon-button" type="button" aria-label="ズーム" title="ズーム" aria-expanded="false"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6.5" fill="none" stroke-width="2"/><path d="m15.5 15.5 5 5" fill="none" stroke-width="2" stroke-linecap="round"/></svg></button>
+          <button id="fullscreen-toggle" class="icon-button" type="button" aria-label="全画面" title="全画面" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9V4h5v2H6v3zm11-5h5v5h-2V6h-3zm3 11h2v5h-5v-2h3zM9 18v2H4v-5h2v3z"/></svg></button>
+          <button id="caption-toggle" class="icon-button" type="button" aria-label="字幕編集" title="字幕編集" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V6h16v12zM6 10h2v2H6zm0 4h8v2H6zm10 0h2v2h-2zm-6-4h8v2h-8z"/></svg></button>
+          <button id="pen-toggle" class="icon-button" type="button" aria-label="ペン" title="ペン" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.5 6.5L17 16l-7 7H2v-8l5.5-5.5zm13.5 0c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zM6.5 9l-3 3H6v2h2v2h2l3-3-3.5-3.5z"/></svg></button>
+          <div id="caption-edit-popup" class="popup" hidden>
+            <div class="popup-header"><span>字幕スタイル</span><span id="caption-id-label"></span></div>
+            <div><label style="color:#aaa;font-size:11px">ゾーン</label><select id="caption-zone-select" style="width:100%;background:#303030;color:#fff;border:1px solid #505050;border-radius:3px;padding:2px 4px;font-size:12px"></select></div>
+            <div style="display:flex;gap:6px;margin-top:6px"><label style="color:#aaa;font-size:11px;flex:1">色 <input id="caption-color-input" type="color" style="width:100%;background:#303030;border:1px solid #505050;border-radius:3px;height:24px"></label><label style="color:#aaa;font-size:11px;flex:1">サイズ <input id="caption-size-input" type="number" min="12" max="120" step="1" style="width:100%;background:#303030;color:#fff;border:1px solid #505050;border-radius:3px;padding:2px 4px;font-size:12px"></label></div>
+          </div>
+          <button id="output-preview-btn" class="icon-button" type="button" aria-label="出力プレビュー" title="出力プレビュー" hidden><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm0 16H5V5h14v14zM7 10h2v7H7zm4-3h2v10h-2zm4 5h2v5h-2z"/></svg></button>
+          <button id="review-record-btn" class="icon-button" type="button" aria-label="レビュー録音" title="レビュー録音" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="6" fill="currentColor"/></svg></button>
+          <span id="review-timer" style="display:none;color:#ff4444;font-size:12px;font-variant-numeric:tabular-nums;min-width:70px;text-align:center">0:00</span>
+          <div id="zoom-popup" class="popup" hidden>
+            <div class="popup-header"><span>ズーム</span><span id="zoom-value">100%</span></div>
+            <input id="zoom-slider" type="range" min="0" max="1" step="0.001" aria-label="ズーム倍率">
+            <div class="zoom-presets"><button class="zoom-preset" type="button" data-zoom="0.5">50%</button><button class="zoom-preset" type="button" data-zoom="1">100%</button><button class="zoom-preset" type="button" data-zoom="2">200%</button><button class="zoom-preset" type="button" data-zoom="4">400%</button></div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -212,101 +293,55 @@ input[type=range] { width: 100%; }
       </div>
     </div>
     <div class="timeline-body">
-      <div class="timeline-headers" id="tl-headers">
-        <div class="timeline-track-header" style="height:22px"> </div>
-        <div class="timeline-track-header">Video</div>
+      <div class="timeline-headers" id="tl-headers"></div>
+    <div class="timeline-canvas-wrap" id="tl-canvas-wrap">
+      <div class="timeline-ruler" id="tl-ruler"><canvas id="tl-ruler-canvas"></canvas></div>
+      <div style="position:relative;flex:1">
+        <canvas id="timeline-canvas"></canvas>
+        <div class="timeline-playhead" id="tl-playhead"></div>
       </div>
-      <div class="timeline-canvas-wrap" id="tl-canvas-wrap">
-        <div class="timeline-ruler" id="tl-ruler"><canvas id="tl-ruler-canvas"></canvas></div>
-        <div style="position:relative;flex:1">
-          <canvas id="timeline-canvas"></canvas>
-          <div class="timeline-playhead" id="tl-playhead"></div>
-        </div>
-      </div>
+    </div>
+    <div id="ctx-menu" hidden>
+      <button id="ctx-split">この位置で分割</button>
+      <button id="ctx-delete">削除</button>
+      <hr>
+      <button id="ctx-add-before">前に追加</button>
+      <button id="ctx-add-after">後に追加</button>
+      <hr>
+      <button id="ctx-move-up">上へ移動</button>
+      <button id="ctx-move-down">下へ移動</button>
+    </div>
+    <div id="asset-ctx-menu" hidden></div>
     </div>
   </div>
 
-  <!-- Transport -->
-  <div class="transport">
-    <div class="transport-waveform" hidden>
-      <div class="waveform-track">
-        <span class="waveform-track-label">Video</span>
-        <div class="waveform-track-visual">
-          <canvas id="waveform-canvas" aria-label="音声波形"></canvas>
-          <div class="transport-waveform-playhead" aria-hidden="true"></div>
-        </div>
-      </div>
-      <div class="waveform-track" id="waveform-track-bgm" hidden>
-        <span class="waveform-track-label">BGM</span>
-        <div class="waveform-track-visual">
-          <canvas class="waveform-track-canvas" data-track="bgm"></canvas>
-          <div class="transport-waveform-playhead" aria-hidden="true"></div>
-        </div>
-      </div>
-      <div class="waveform-track" id="waveform-track-narration" hidden>
-        <span class="waveform-track-label">Nar</span>
-        <div class="waveform-track-visual">
-          <canvas class="waveform-track-canvas" data-track="narration"></canvas>
-          <div class="transport-waveform-playhead" aria-hidden="true"></div>
-        </div>
-      </div>
-      <div class="waveform-track" id="waveform-track-sfx" hidden>
-        <span class="waveform-track-label">SFX</span>
-        <div class="waveform-track-visual">
-          <canvas class="waveform-track-canvas" data-track="sfx"></canvas>
-          <div class="transport-waveform-playhead" aria-hidden="true"></div>
-        </div>
+  <div class="transport-waveform" hidden>
+    <div class="waveform-track">
+      <span class="waveform-track-label">Video</span>
+      <div class="waveform-track-visual">
+        <canvas id="waveform-canvas" aria-label="音声波形"></canvas>
+        <div class="transport-waveform-playhead" aria-hidden="true"></div>
       </div>
     </div>
-    <div class="transport-seek">
-      <div id="seek-visual" style="position:absolute;inset:0;display:flex;pointer-events:none;border-radius:3px;overflow:hidden;opacity:0.35"></div>
-      <input id="seek" type="range" min="0" max="0" step="0.001" value="0" aria-label="再生位置">
-      <div id="cut-info-popup" class="popup" style="left:0;right:auto;width:280px" hidden>
-        <div class="popup-header"><span>カット情報</span></div>
-        <div id="cut-info-content" style="font-size:12px;color:#ccc;line-height:1.6"></div>
+    <div class="waveform-track" id="waveform-track-bgm" hidden>
+      <span class="waveform-track-label">BGM</span>
+      <div class="waveform-track-visual">
+        <canvas class="waveform-track-canvas" data-track="bgm"></canvas>
+        <div class="transport-waveform-playhead" aria-hidden="true"></div>
       </div>
     </div>
-    <div class="transport-controls">
-      <div class="transport-left">
-        <button id="waveform-toggle" class="icon-button" type="button" aria-label="波形" title="波形" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h2m2-4v8m3-12v16m3-13v10m3-7v4m3-2h2" fill="none" stroke-width="2" stroke-linecap="round"/></svg></button>
-        <span id="time-label">0:00 / 0:00</span>
-        <button id="edit-toggle" class="icon-button" type="button" aria-label="編集" title="編集" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a1.0 1.0 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg></button>
-        <button id="indicator-toggle" class="icon-button" type="button" aria-label="指標" title="指標" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg></button>
-        <span id="selection-label"></span>
-        <div id="indicator-popup" class="indicator-popup" hidden></div>
+    <div class="waveform-track" id="waveform-track-narration" hidden>
+      <span class="waveform-track-label">Nar</span>
+      <div class="waveform-track-visual">
+        <canvas class="waveform-track-canvas" data-track="narration"></canvas>
+        <div class="transport-waveform-playhead" aria-hidden="true"></div>
       </div>
-      <div class="transport-center">
-        <button id="skip-back" class="icon-button" type="button" aria-label="10秒戻る" title="10秒戻る"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M11 5V2L6.5 6 11 10V7a6 6 0 1 1-5.65 8H3.26A8 8 0 1 0 11 5Z"/><text x="8" y="17" fill="currentColor" stroke="none" font-size="7" font-family="system-ui,sans-serif" font-weight="700">10</text></svg></button>
-        <button id="frame-back" class="icon-button" type="button" aria-label="1コマ戻る" title="1コマ戻る"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 5h2v14H6zM18 5v14l-9-7z"/></svg></button>
-        <button id="play-toggle" class="icon-button" type="button" aria-label="再生" title="再生"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></button>
-        <button id="frame-forward" class="icon-button" type="button" aria-label="1コマ進む" title="1コマ進む"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 5h2v14h-2zM6 5v14l9-7z"/></svg></button>
-        <button id="skip-forward" class="icon-button" type="button" aria-label="10秒進む" title="10秒進む"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 5V2l4.5 4-4.5 4V7a6 6 0 1 0 5.65 8h2.09A8 8 0 1 1 13 5Z"/><text x="8" y="17" fill="currentColor" stroke="none" font-size="7" font-family="system-ui,sans-serif" font-weight="700">10</text></svg></button>
-      </div>
-      <div class="transport-right">
-        <div class="transform-popup" id="transform-popup" hidden>
-          <div class="popup-header"><span>トランスフォーム</span></div>
-          <div class="transform-row"><label>X</label><input id="tx" type="number" step="1"></div>
-          <div class="transform-row"><label>Y</label><input id="ty" type="number" step="1"></div>
-          <div class="transform-row"><label>拡大</label><input id="ts" type="number" step="0.01" min="0.01"></div>
-          <div class="transform-row"><label>回転</label><input id="tr" type="number" step="1"></div>
-        </div>
-        <button id="zoom-toggle" class="icon-button" type="button" aria-label="ズーム" title="ズーム" aria-expanded="false"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6.5" fill="none" stroke-width="2"/><path d="m15.5 15.5 5 5" fill="none" stroke-width="2" stroke-linecap="round"/></svg></button>
-        <button id="fullscreen-toggle" class="icon-button" type="button" aria-label="全画面" title="全画面" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9V4h5v2H6v3zm11-5h5v5h-2V6h-3zm3 11h2v5h-5v-2h3zM9 18v2H4v-5h2v3z"/></svg></button>
-        <button id="caption-toggle" class="icon-button" type="button" aria-label="字幕編集" title="字幕編集" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V6h16v12zM6 10h2v2H6zm0 4h8v2H6zm10 0h2v2h-2zm-6-4h8v2h-8z"/></svg></button>
-        <button id="pen-toggle" class="icon-button" type="button" aria-label="ペン" title="ペン" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a1.0 1.0 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg></button>
-        <div id="caption-edit-popup" class="popup" hidden>
-          <div class="popup-header"><span>字幕スタイル</span><span id="caption-id-label"></span></div>
-          <div><label style="color:#aaa;font-size:11px">ゾーン</label><select id="caption-zone-select" style="width:100%;background:#303030;color:#fff;border:1px solid #505050;border-radius:3px;padding:2px 4px;font-size:12px"></select></div>
-          <div style="display:flex;gap:6px;margin-top:6px"><label style="color:#aaa;font-size:11px;flex:1">色 <input id="caption-color-input" type="color" style="width:100%;background:#303030;border:1px solid #505050;border-radius:3px;height:24px"></label><label style="color:#aaa;font-size:11px;flex:1">サイズ <input id="caption-size-input" type="number" min="12" max="120" step="1" style="width:100%;background:#303030;color:#fff;border:1px solid #505050;border-radius:3px;padding:2px 4px;font-size:12px"></label></div>
-        </div>
-        <button id="output-preview-btn" class="icon-button" type="button" aria-label="出力プレビュー" title="出力プレビュー" hidden><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm0 16H5V5h14v14zM7 10h2v7H7zm4-3h2v10h-2zm4 5h2v5h-2z"/></svg></button>
-        <button id="review-record-btn" class="icon-button" type="button" aria-label="レビュー録音" title="レビュー録音" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="6" fill="currentColor"/></svg></button>
-        <span id="review-timer" style="display:none;color:#ff4444;font-size:12px;font-variant-numeric:tabular-nums;min-width:70px;text-align:center">0:00</span>
-        <div id="zoom-popup" class="popup" hidden>
-          <div class="popup-header"><span>ズーム</span><span id="zoom-value">100%</span></div>
-          <input id="zoom-slider" type="range" min="0" max="1" step="0.001" aria-label="ズーム倍率">
-          <div class="zoom-presets"><button class="zoom-preset" type="button" data-zoom="0.5">50%</button><button class="zoom-preset" type="button" data-zoom="1">100%</button><button class="zoom-preset" type="button" data-zoom="2">200%</button><button class="zoom-preset" type="button" data-zoom="4">400%</button></div>
-        </div>
+    </div>
+    <div class="waveform-track" id="waveform-track-sfx" hidden>
+      <span class="waveform-track-label">SFX</span>
+      <div class="waveform-track-visual">
+        <canvas class="waveform-track-canvas" data-track="sfx"></canvas>
+        <div class="transport-waveform-playhead" aria-hidden="true"></div>
       </div>
     </div>
   </div>
@@ -330,6 +365,28 @@ input[type=range] { width: 100%; }
   </div>
 </div>
 
+<div id="add-track-dialog" hidden>
+  <div id="add-track-dialog-inner">
+    <h3>新規トラックを作成</h3>
+    <div class="field">
+      <label for="atd-type">トラックの種類</label>
+      <select id="atd-type">
+        <option value="video">ビデオ（オーバーレイ）</option>
+        <option value="audio">ミュージック</option>
+        <option value="narration">ナレーション</option>
+        <option value="sfx">効果音</option>
+      </select>
+    </div>
+    <div class="field">
+      <label for="atd-name">トラック名</label>
+      <input id="atd-name" type="text" placeholder="トラック名を入力">
+    </div>
+    <div class="btns">
+      <button id="atd-cancel">キャンセル</button>
+      <button id="atd-ok" class="primary">作成</button>
+    </div>
+  </div>
+</div>
 <script src="/overlay-interaction.js"></script>
 <script type="module" src="/app.js"></script>
 </body>

--- a/packages/preview-server/public/index.html
+++ b/packages/preview-server/public/index.html
@@ -9,10 +9,41 @@
 @keyframes spin { to { transform: rotate(360deg); } }
 * { box-sizing: border-box; }
 html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; background: #141414; color: #eee; }
-body { display: grid; grid-template-rows: minmax(0, 1fr) auto; }
-.workspace { min-height: 0; display: grid; grid-template-columns: minmax(0, 1fr); }
-.preview-pane { min-width: 0; min-height: 0; padding: 16px; display: grid; place-items: center; background: #090909; }
-#preview-wrapper { position: relative; width: 100%; max-height: 100%; aspect-ratio: 16 / 9; overflow: hidden; background: #000; }
+
+.app-root { width: 100%; height: 100%; display: grid; grid-template-rows: 1fr auto auto; min-height: 0; }
+
+.main-panes { min-height: 0; display: grid; grid-template-columns: 260px 1fr; overflow: hidden; }
+
+.pane { display: flex; flex-direction: column; min-height: 0; }
+.pane-header { display: flex; align-items: center; gap: 8px; padding: 6px 10px; background: #1a1a1a; border-bottom: 1px solid #303030; font-size: 12px; font-weight: 600; color: #aaa; flex-shrink: 0; }
+.pane-content { flex: 1; min-height: 0; overflow: auto; }
+
+/* Asset browser */
+.pane-left { border-right: 1px solid #303030; background: #181818; }
+.pane-left .pane-header { justify-content: space-between; }
+.asset-tabs { display: flex; gap: 2px; }
+.asset-tab { padding: 2px 8px; border: 1px solid #404040; border-radius: 3px; background: #252525; color: #888; font-size: 10px; cursor: pointer; }
+.asset-tab.active { background: #4da3ff; color: #fff; border-color: #4da3ff; }
+.asset-search { width: 100%; padding: 6px 8px; background: #222; border: none; border-bottom: 1px solid #303030; color: #ccc; font-size: 12px; outline: none; }
+.asset-search::placeholder { color: #555; }
+.asset-item { display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-bottom: 1px solid #252525; cursor: pointer; transition: background 0.15s; }
+.asset-item:hover { background: #222; }
+.asset-item:active { background: #2a2a2a; }
+.asset-item.is-active { background: #1a3050; }
+.asset-icon { flex-shrink: 0; width: 28px; height: 28px; border-radius: 3px; background: #222; display: grid; place-items: center; font-size: 14px; }
+.asset-icon.video { color: #4da3ff; }
+.asset-icon.audio { color: #ffd94a; }
+.asset-icon.image { color: #51cf66; }
+.asset-info { flex: 1; min-width: 0; }
+.asset-name { font-size: 12px; color: #ddd; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.asset-meta { font-size: 10px; color: #666; }
+.asset-size { flex-shrink: 0; font-size: 10px; color: #555; padding-right: 4px; }
+.asset-empty { padding: 20px; text-align: center; color: #555; font-size: 12px; }
+
+/* Preview */
+.pane-center { min-width: 0; display: grid; grid-template-rows: 1fr; background: #090909; }
+.preview-area { min-height: 0; padding: 12px; display: grid; place-items: center; }
+#preview-wrapper { position: relative; width: 100%; max-height: 100%; aspect-ratio: 16 / 9; overflow: hidden; background: #000; border-radius: 4px; }
 #zoom-layer { position: absolute; inset: 0; overflow: hidden; will-change: transform; }
 #preview-video { position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: contain; }
 #layer-container { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; }
@@ -22,9 +53,7 @@ body { display: grid; grid-template-rows: minmax(0, 1fr) auto; }
 #transition-plate { position: absolute; inset: 0; z-index: 2147483646; opacity: 0; pointer-events: none; background: #000; }
 #caption-plate { position: absolute; left: 50%; bottom: 7%; z-index: 2147483647; max-width: 88%; transform: translateX(-50%); padding: 0.35em 0.7em; border-radius: 0.18em; background: rgba(0, 0, 0, 0.78); color: #fff; font-size: 18px; font-weight: 700; line-height: 1.45; text-align: center; text-shadow: 0 1px 2px #000; white-space: pre-wrap; pointer-events: auto; cursor: move; user-select: none; }
 #caption-plate:empty { display: none; }
-#caption-plate.akari-caption-styled { inset: 0; max-width: none; transform: none; padding: 0; border-radius: 0; background: none; text-shadow: none; white-space: normal; --caption-color: #fff; --caption-font-size: 38px; }
-#caption-plate.akari-caption-styled .akari-caption__plate { position: absolute; top: var(--caption-top, auto); left: var(--caption-left, 0); right: var(--caption-right, 0); bottom: var(--caption-bottom, 7%); display: flex; flex-direction: column; justify-content: var(--caption-justify-content, flex-start); align-items: var(--caption-align-items, center); }
-#caption-plate.akari-caption-styled .akari-caption__text { color: var(--caption-color, #fff); font-size: var(--caption-font-size, 38px); font-weight: 700; line-height: 1.45; text-align: var(--caption-text-align, center); text-shadow: -1.5px -1.5px 0 rgba(0,0,0,.85), 1.5px -1.5px 0 rgba(0,0,0,.85), -1.5px 1.5px 0 rgba(0,0,0,.85), 1.5px 1.5px 0 rgba(0,0,0,.85), 0 0 8px rgba(0,0,0,.6); white-space: pre-wrap; padding: 0.35em 0.7em; }
+#caption-plate.akari-caption-styled { inset: 0; max-width: none; transform: none; padding: 0; border-radius: 0; background: none; text-shadow: none; white-space: normal; }
 #caption-select-box { position: absolute; z-index: 1900; border: 1.5px dashed #4da3ff; box-shadow: 0 0 0 1px rgba(0,0,0,0.35); pointer-events: none; display: none; }
 #caption-select-box.is-active { display: block; }
 #shortcut-help { position: fixed; inset: 0; z-index: 9999; background: rgba(0,0,0,0.7); display: grid; place-items: center; }
@@ -53,28 +82,46 @@ body { display: grid; grid-template-rows: minmax(0, 1fr) auto; }
 .message-card { position: absolute; inset: 0; z-index: 10; display: grid; gap: 16px; place-items: center; padding: 32px; background: #111; }
 .message-card[hidden] { display: none; }
 .message-card p { max-width: 520px; margin: 0; color: #e5e5e5; font-size: 15px; line-height: 1.7; text-align: center; }
-.transport { display: grid; gap: 8px; padding: 9px 14px 10px; border-top: 1px solid #303030; background: #202020; }
-.transport-waveform { width: 100%; overflow: hidden; border-top: 1px solid #303030; background: #181818; }
+
+/* Timeline pane */
+.pane-bottom { border-top: 1px solid #303030; background: #1a1a1a; }
+.pane-bottom .pane-header { border-bottom-color: #383838; }
+.timeline-controls { margin-left: auto; display: flex; align-items: center; gap: 4px; }
+.tl-btn { width: 22px; height: 22px; border: 1px solid #404040; border-radius: 3px; background: #252525; color: #aaa; font-size: 11px; cursor: pointer; display: grid; place-items: center; }
+.tl-btn:hover { background: #333; border-color: #555; }
+#tl-zoom-label { font-size: 10px; color: #666; min-width: 32px; text-align: center; }
+.timeline-body { display: flex; flex: 1; min-height: 0; overflow: hidden; }
+.timeline-headers { flex-shrink: 0; width: 70px; border-right: 1px solid #303030; background: #161616; }
+.timeline-track-header { height: 28px; display: flex; align-items: center; padding: 0 8px; font-size: 9px; color: #666; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; border-bottom: 1px solid #282828; }
+.timeline-canvas-wrap { flex: 1; min-width: 0; overflow-x: auto; overflow-y: hidden; position: relative; }
+#timeline-canvas { display: block; height: 100%; }
+.timeline-playhead { position: absolute; top: 0; bottom: 0; width: 1px; background: #fff; pointer-events: none; z-index: 5; }
+.timeline-ruler { position: relative; height: 22px; border-bottom: 1px solid #303030; background: #141414; overflow: hidden; }
+#tl-ruler-canvas { display: block; width: 100%; height: 100%; }
+
+/* Transport */
+.transport { display: grid; gap: 6px; padding: 6px 12px 8px; border-top: 1px solid #303030; background: #1e1e1e; }
+.transport-waveform { width: 100%; overflow: hidden; }
 .transport-waveform[hidden] { display: none; }
-.waveform-track { position: relative; height: 28px; display: flex; align-items: center; border-bottom: 1px solid #282828; cursor: pointer; touch-action: none; }
-.waveform-track-label { position: absolute; left: 4px; z-index: 2; color: #888; font-size: 9px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; pointer-events: none; text-shadow: 0 0 3px #000; }
+.waveform-track { position: relative; height: 22px; display: flex; align-items: center; border-bottom: 1px solid #282828; cursor: pointer; touch-action: none; }
+.waveform-track-label { position: absolute; left: 4px; z-index: 2; color: #666; font-size: 8px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; pointer-events: none; text-shadow: 0 0 3px #000; }
 .waveform-track-visual { position: absolute; inset: 0; }
 .waveform-track-canvas, #waveform-canvas { display: block; width: 100%; height: 100%; }
 .transport-waveform-playhead { position: absolute; top: 0; bottom: 0; left: 0; width: 1px; background: rgba(255, 255, 255, 0.7); pointer-events: none; z-index: 1; }
-.transport-seek { display: flex; width: 100%; }
+.transport-seek { display: flex; width: 100%; position: relative; }
 .transport-seek input { width: 100%; }
 .transport-controls { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; min-width: 0; }
-.transport-left, .transport-center, .transport-right { display: flex; align-items: center; gap: 8px; }
+.transport-left, .transport-center, .transport-right { display: flex; align-items: center; gap: 6px; }
 .transport-left, .transport-center { position: relative; min-width: 0; }
 .transport-left { justify-self: start; }
 .transport-center { justify-self: center; }
 .transport-right { position: relative; justify-self: end; }
-.icon-button { display: inline-grid; place-items: center; width: 32px; height: 32px; border: 1px solid #505050; border-radius: 4px; padding: 0; background: #303030; color: #fff; cursor: pointer; }
+.icon-button { display: inline-grid; place-items: center; width: 30px; height: 30px; border: 1px solid #505050; border-radius: 4px; padding: 0; background: #303030; color: #fff; cursor: pointer; }
 .icon-button[hidden] { display: none; }
 .icon-button[aria-pressed="true"] { border-color: #f2f4fa; background: #555b67; box-shadow: 0 0 8px rgba(236,242,255,0.48); }
 .icon-button:disabled { opacity: 0.45; cursor: default; }
-.icon-button svg { width: 18px; height: 18px; fill: currentColor; stroke: currentColor; }
-#time-label { min-width: 104px; color: #d0d0d0; font-variant-numeric: tabular-nums; text-align: left; }
+.icon-button svg { width: 16px; height: 16px; fill: currentColor; stroke: currentColor; }
+#time-label { min-width: 100px; color: #d0d0d0; font-variant-numeric: tabular-nums; text-align: left; font-size: 13px; }
 .popup { position: absolute; right: 0; bottom: calc(100% + 8px); z-index: 20; width: 224px; border: 1px solid #505050; border-radius: 6px; padding: 10px; background: #202020; box-shadow: 0 4px 16px rgba(0,0,0,0.45); }
 .popup[hidden] { display: none; }
 .popup-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; color: #d8d8d8; font-size: 12px; }
@@ -94,115 +141,193 @@ input[type=range] { width: 100%; }
 .indicator-item { display: flex; gap: 6px; margin-bottom: 3px; font-size: 12px; color: #ccc; }
 .indicator-item .key { color: #8af; min-width: 100px; }
 .indicator-item .val { color: #aaa; }
+
+/* Status bar */
+#status-bar { position: absolute; top: 8px; left: 50%; transform: translateX(-50%); z-index: 10; pointer-events: none; display: flex; gap: 12px; background: rgba(0,0,0,0.55); border-radius: 4px; padding: 3px 10px; font-size: 11px; color: #ccc; font-variant-numeric: tabular-nums; opacity: 0; transition: opacity 0.3s; }
+#loading-indicator { position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);z-index:5;text-align:center;display:none; }
+#loading-indicator > div:first-child { width:32px;height:32px;border:3px solid #505050;border-top-color:#4da3ff;border-radius:50%;animation:spin 0.8s linear infinite;margin:0 auto 8px; }
+#loading-indicator > div:last-child { color:#888;font-size:12px; }
+
+/* Resize handle */
+.pane-left-resize { flex-shrink: 0; width: 4px; cursor: col-resize; background: transparent; transition: background 0.2s; }
+.pane-left-resize:hover { background: #4da3ff; }
 </style>
 </head>
 <body>
-<main class="workspace">
-  <section class="preview-pane" aria-label="動画プレビュー">
-    <div id="status-bar" style="position:absolute;top:8px;left:50%;transform:translateX(-50%);z-index:10;pointer-events:none;display:flex;gap:12px;background:rgba(0,0,0,0.55);border-radius:4px;padding:3px 10px;font-size:11px;color:#ccc;font-variant-numeric:tabular-nums;opacity:0;transition:opacity 0.3s"><span id="status-info"></span></div>
-    <div id="preview-wrapper">
-      <div id="zoom-layer">
-        <video id="preview-video" preload="auto"></video>
-        <div id="layer-container"></div>
-        <div id="overlay-stage"><div id="pen-layer"><canvas id="pen-canvas"></canvas></div><div id="transition-plate"></div><div id="caption-plate"></div><div id="caption-select-box"></div><div id="layer-select-box"><div class="akari-layer-handle akari-layer-handle-nw" data-handle="nw"></div><div class="akari-layer-handle akari-layer-handle-ne" data-handle="ne"></div><div class="akari-layer-handle akari-layer-handle-sw" data-handle="sw"></div><div class="akari-layer-handle akari-layer-handle-se" data-handle="se"></div><div class="akari-layer-handle akari-layer-handle-rotate" data-handle="rotate"></div></div></div>
+<div class="app-root">
+  <div class="main-panes">
+    <!-- Left: Asset Browser -->
+    <aside class="pane pane-left" id="asset-pane">
+      <div class="pane-header">
+        <span>素材</span>
+        <div class="asset-tabs" id="asset-tabs">
+          <button class="asset-tab active" data-cat="all">すべて</button>
+          <button class="asset-tab" data-cat="video">動画</button>
+          <button class="asset-tab" data-cat="audio">音声</button>
+          <button class="asset-tab" data-cat="image">画像</button>
+        </div>
       </div>
-      <div id="loading-indicator" style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);z-index:5;text-align:center;display:none"><div style="width:32px;height:32px;border:3px solid #505050;border-top-color:#4da3ff;border-radius:50%;animation:spin 0.8s linear infinite;margin:0 auto 8px"></div><div style="color:#888;font-size:12px">読み込み中...</div></div>
-      <div id="zoom-minimap" hidden><video id="minimap-video" preload="auto"></video><div id="zoom-minimap-viewport"></div></div>
-      <div id="preview-message" class="message-card" hidden role="status">
-        <p id="preview-message-text"></p>
-      </div>
-    </div>
-  </section>
-</main>
-<div class="transport">
-  <div class="transport-waveform" hidden>
-    <div class="waveform-track">
-      <span class="waveform-track-label">Video</span>
-      <div class="waveform-track-visual">
-        <canvas id="waveform-canvas" aria-label="音声波形"></canvas>
-        <div class="transport-waveform-playhead" aria-hidden="true"></div>
-      </div>
-    </div>
-    <div class="waveform-track" id="waveform-track-bgm" hidden>
-      <span class="waveform-track-label">BGM</span>
-      <div class="waveform-track-visual">
-        <canvas class="waveform-track-canvas" data-track="bgm"></canvas>
-        <div class="transport-waveform-playhead" aria-hidden="true"></div>
-      </div>
-    </div>
-    <div class="waveform-track" id="waveform-track-narration" hidden>
-      <span class="waveform-track-label">Nar</span>
-      <div class="waveform-track-visual">
-        <canvas class="waveform-track-canvas" data-track="narration"></canvas>
-        <div class="transport-waveform-playhead" aria-hidden="true"></div>
-      </div>
-    </div>
-    <div class="waveform-track" id="waveform-track-sfx" hidden>
-      <span class="waveform-track-label">SFX</span>
-      <div class="waveform-track-visual">
-        <canvas class="waveform-track-canvas" data-track="sfx"></canvas>
-        <div class="transport-waveform-playhead" aria-hidden="true"></div>
+      <input class="asset-search" id="asset-search" type="search" placeholder="素材を検索..." spellcheck="false">
+      <div class="pane-content" id="asset-list"></div>
+    </aside>
+
+    <!-- Center: Preview -->
+    <div class="pane pane-center">
+      <div class="preview-area">
+        <div id="preview-wrapper">
+          <div id="zoom-layer">
+            <video id="preview-video" preload="auto"></video>
+            <div id="layer-container"></div>
+            <div id="overlay-stage">
+              <div id="pen-layer"><canvas id="pen-canvas"></canvas></div>
+              <div id="transition-plate"></div>
+              <div id="caption-plate"></div>
+              <div id="caption-select-box"></div>
+              <div id="layer-select-box">
+                <div class="akari-layer-handle akari-layer-handle-nw" data-handle="nw"></div>
+                <div class="akari-layer-handle akari-layer-handle-ne" data-handle="ne"></div>
+                <div class="akari-layer-handle akari-layer-handle-sw" data-handle="sw"></div>
+                <div class="akari-layer-handle akari-layer-handle-se" data-handle="se"></div>
+                <div class="akari-layer-handle akari-layer-handle-rotate" data-handle="rotate"></div>
+              </div>
+            </div>
+          </div>
+          <div id="loading-indicator"><div></div><div>読み込み中...</div></div>
+          <div id="zoom-minimap" hidden><video id="minimap-video" preload="auto"></video><div id="zoom-minimap-viewport"></div></div>
+          <div id="preview-message" class="message-card" hidden role="status"><p id="preview-message-text"></p></div>
+        </div>
       </div>
     </div>
   </div>
-  <div class="transport-seek" style="position:relative">
-    <div id="seek-visual" style="position:absolute;inset:0;display:flex;pointer-events:none;border-radius:3px;overflow:hidden;opacity:0.35"></div>
-    <input id="seek" type="range" min="0" max="0" step="0.001" value="0" aria-label="再生位置">
-    <div id="cut-info-popup" class="popup" style="left:0;right:auto;width:280px" hidden>
-      <div class="popup-header"><span>カット情報</span></div>
-      <div id="cut-info-content" style="font-size:12px;color:#ccc;line-height:1.6"></div>
+
+  <!-- Bottom: Timeline -->
+  <div class="pane pane-bottom" id="timeline-pane">
+    <div class="pane-header">
+      <span>タイムライン</span>
+      <div class="timeline-controls">
+        <button class="tl-btn" id="tl-zoom-out" title="縮小">−</button>
+        <span id="tl-zoom-label">100%</span>
+        <button class="tl-btn" id="tl-zoom-in" title="拡大">＋</button>
+        <button class="tl-btn" id="tl-fit-btn" title="全体表示" style="margin-left:4px">⤡</button>
+      </div>
+    </div>
+    <div class="timeline-body">
+      <div class="timeline-headers" id="tl-headers">
+        <div class="timeline-track-header" style="height:22px"> </div>
+        <div class="timeline-track-header">Video</div>
+      </div>
+      <div class="timeline-canvas-wrap" id="tl-canvas-wrap">
+        <div class="timeline-ruler" id="tl-ruler"><canvas id="tl-ruler-canvas"></canvas></div>
+        <div style="position:relative;flex:1">
+          <canvas id="timeline-canvas"></canvas>
+          <div class="timeline-playhead" id="tl-playhead"></div>
+        </div>
+      </div>
     </div>
   </div>
-  <div class="transport-controls">
-    <div class="transport-left">
-      <button id="waveform-toggle" class="icon-button" type="button" aria-label="波形" title="波形" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h2m2-4v8m3-12v16m3-13v10m3-7v4m3-2h2" fill="none" stroke-width="2" stroke-linecap="round"/></svg></button>
-      <span id="time-label">0:00 / 0:00</span>
-      <button id="edit-toggle" class="icon-button" type="button" aria-label="編集" title="編集" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a1.0 1.0 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg></button>
-      <button id="indicator-toggle" class="icon-button" type="button" aria-label="指標" title="指標" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg></button>
-      <span id="selection-label"></span>
-      <div id="indicator-popup" class="indicator-popup" hidden></div>
-    </div>
-    <div class="transport-center">
-      <button id="skip-back" class="icon-button" type="button" aria-label="10秒戻る" title="10秒戻る"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M11 5V2L6.5 6 11 10V7a6 6 0 1 1-5.65 8H3.26A8 8 0 1 0 11 5Z"/><text x="8" y="17" fill="currentColor" stroke="none" font-size="7" font-family="system-ui,sans-serif" font-weight="700">10</text></svg></button>
-      <button id="frame-back" class="icon-button" type="button" aria-label="1コマ戻る" title="1コマ戻る"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 5h2v14H6zM18 5v14l-9-7z"/></svg></button>
-      <button id="play-toggle" class="icon-button" type="button" aria-label="再生" title="再生"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></button>
-      <button id="frame-forward" class="icon-button" type="button" aria-label="1コマ進む" title="1コマ進む"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 5h2v14h-2zM6 5v14l9-7z"/></svg></button>
-      <button id="skip-forward" class="icon-button" type="button" aria-label="10秒進む" title="10秒進む"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 5V2l4.5 4-4.5 4V7a6 6 0 1 0 5.65 8h2.09A8 8 0 1 1 13 5Z"/><text x="8" y="17" fill="currentColor" stroke="none" font-size="7" font-family="system-ui,sans-serif" font-weight="700">10</text></svg></button>
-    </div>
-    <div class="transport-right">
-      <div class="transform-popup" id="transform-popup" hidden>
-        <div class="popup-header"><span>トランスフォーム</span></div>
-        <div class="transform-row"><label>X</label><input id="tx" type="number" step="1"></div>
-        <div class="transform-row"><label>Y</label><input id="ty" type="number" step="1"></div>
-        <div class="transform-row"><label>拡大</label><input id="ts" type="number" step="0.01" min="0.01"></div>
-        <div class="transform-row"><label>回転</label><input id="tr" type="number" step="1"></div>
+
+  <!-- Transport -->
+  <div class="transport">
+    <div class="transport-waveform" hidden>
+      <div class="waveform-track">
+        <span class="waveform-track-label">Video</span>
+        <div class="waveform-track-visual">
+          <canvas id="waveform-canvas" aria-label="音声波形"></canvas>
+          <div class="transport-waveform-playhead" aria-hidden="true"></div>
+        </div>
       </div>
-      <button id="zoom-toggle" class="icon-button" type="button" aria-label="ズーム" title="ズーム" aria-expanded="false"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6.5" fill="none" stroke-width="2"/><path d="m15.5 15.5 5 5" fill="none" stroke-width="2" stroke-linecap="round"/></svg></button>
-      <button id="fullscreen-toggle" class="icon-button" type="button" aria-label="全画面" title="全画面" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9V4h5v2H6v3zm11-5h5v5h-2V6h-3zm3 11h2v5h-5v-2h3zM9 18v2H4v-5h2v3z"/></svg></button>
-      <button id="caption-toggle" class="icon-button" type="button" aria-label="字幕編集" title="字幕編集" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V6h16v12zM6 10h2v2H6zm0 4h8v2H6zm10 0h2v2h-2zm-6-4h8v2h-8z"/></svg></button>
-      <button id="pen-toggle" class="icon-button" type="button" aria-label="ペン" title="ペン" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a1.0 1.0 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg></button>
-      <div id="caption-edit-popup" class="popup" hidden>
-        <div class="popup-header"><span>字幕スタイル</span><span id="caption-id-label"></span></div>
-        <div><label style="color:#aaa;font-size:11px">ゾーン</label><select id="caption-zone-select" style="width:100%;background:#303030;color:#fff;border:1px solid #505050;border-radius:3px;padding:2px 4px;font-size:12px"></select></div>
-        <div style="display:flex;gap:6px;margin-top:6px"><label style="color:#aaa;font-size:11px;flex:1">色 <input id="caption-color-input" type="color" style="width:100%;background:#303030;border:1px solid #505050;border-radius:3px;height:24px"></label><label style="color:#aaa;font-size:11px;flex:1">サイズ <input id="caption-size-input" type="number" min="12" max="120" step="1" style="width:100%;background:#303030;color:#fff;border:1px solid #505050;border-radius:3px;padding:2px 4px;font-size:12px"></label></div>
+      <div class="waveform-track" id="waveform-track-bgm" hidden>
+        <span class="waveform-track-label">BGM</span>
+        <div class="waveform-track-visual">
+          <canvas class="waveform-track-canvas" data-track="bgm"></canvas>
+          <div class="transport-waveform-playhead" aria-hidden="true"></div>
+        </div>
       </div>
-      <button id="output-preview-btn" class="icon-button" type="button" aria-label="出力プレビュー" title="出力プレビュー" hidden><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm0 16H5V5h14v14zM7 10h2v7H7zm4-3h2v10h-2zm4 5h2v5h-2z"/></svg></button>
-      <button id="review-record-btn" class="icon-button" type="button" aria-label="レビュー録音" title="レビュー録音" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="6" fill="currentColor"/></svg></button>
-      <span id="review-timer" style="display:none;color:#ff4444;font-size:12px;font-variant-numeric:tabular-nums;min-width:70px;text-align:center">0:00</span>
-      <div id="zoom-popup" class="popup" hidden>
-        <div class="popup-header"><span>ズーム</span><span id="zoom-value">100%</span></div>
-        <input id="zoom-slider" type="range" min="0" max="1" step="0.001" aria-label="ズーム倍率">
-        <div class="zoom-presets">
-          <button class="zoom-preset" type="button" data-zoom="0.5">50%</button>
-          <button class="zoom-preset" type="button" data-zoom="1">100%</button>
-          <button class="zoom-preset" type="button" data-zoom="2">200%</button>
-          <button class="zoom-preset" type="button" data-zoom="4">400%</button>
+      <div class="waveform-track" id="waveform-track-narration" hidden>
+        <span class="waveform-track-label">Nar</span>
+        <div class="waveform-track-visual">
+          <canvas class="waveform-track-canvas" data-track="narration"></canvas>
+          <div class="transport-waveform-playhead" aria-hidden="true"></div>
+        </div>
+      </div>
+      <div class="waveform-track" id="waveform-track-sfx" hidden>
+        <span class="waveform-track-label">SFX</span>
+        <div class="waveform-track-visual">
+          <canvas class="waveform-track-canvas" data-track="sfx"></canvas>
+          <div class="transport-waveform-playhead" aria-hidden="true"></div>
+        </div>
+      </div>
+    </div>
+    <div class="transport-seek">
+      <div id="seek-visual" style="position:absolute;inset:0;display:flex;pointer-events:none;border-radius:3px;overflow:hidden;opacity:0.35"></div>
+      <input id="seek" type="range" min="0" max="0" step="0.001" value="0" aria-label="再生位置">
+      <div id="cut-info-popup" class="popup" style="left:0;right:auto;width:280px" hidden>
+        <div class="popup-header"><span>カット情報</span></div>
+        <div id="cut-info-content" style="font-size:12px;color:#ccc;line-height:1.6"></div>
+      </div>
+    </div>
+    <div class="transport-controls">
+      <div class="transport-left">
+        <button id="waveform-toggle" class="icon-button" type="button" aria-label="波形" title="波形" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h2m2-4v8m3-12v16m3-13v10m3-7v4m3-2h2" fill="none" stroke-width="2" stroke-linecap="round"/></svg></button>
+        <span id="time-label">0:00 / 0:00</span>
+        <button id="edit-toggle" class="icon-button" type="button" aria-label="編集" title="編集" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a1.0 1.0 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg></button>
+        <button id="indicator-toggle" class="icon-button" type="button" aria-label="指標" title="指標" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg></button>
+        <span id="selection-label"></span>
+        <div id="indicator-popup" class="indicator-popup" hidden></div>
+      </div>
+      <div class="transport-center">
+        <button id="skip-back" class="icon-button" type="button" aria-label="10秒戻る" title="10秒戻る"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M11 5V2L6.5 6 11 10V7a6 6 0 1 1-5.65 8H3.26A8 8 0 1 0 11 5Z"/><text x="8" y="17" fill="currentColor" stroke="none" font-size="7" font-family="system-ui,sans-serif" font-weight="700">10</text></svg></button>
+        <button id="frame-back" class="icon-button" type="button" aria-label="1コマ戻る" title="1コマ戻る"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 5h2v14H6zM18 5v14l-9-7z"/></svg></button>
+        <button id="play-toggle" class="icon-button" type="button" aria-label="再生" title="再生"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></button>
+        <button id="frame-forward" class="icon-button" type="button" aria-label="1コマ進む" title="1コマ進む"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 5h2v14h-2zM6 5v14l9-7z"/></svg></button>
+        <button id="skip-forward" class="icon-button" type="button" aria-label="10秒進む" title="10秒進む"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 5V2l4.5 4-4.5 4V7a6 6 0 1 0 5.65 8h2.09A8 8 0 1 1 13 5Z"/><text x="8" y="17" fill="currentColor" stroke="none" font-size="7" font-family="system-ui,sans-serif" font-weight="700">10</text></svg></button>
+      </div>
+      <div class="transport-right">
+        <div class="transform-popup" id="transform-popup" hidden>
+          <div class="popup-header"><span>トランスフォーム</span></div>
+          <div class="transform-row"><label>X</label><input id="tx" type="number" step="1"></div>
+          <div class="transform-row"><label>Y</label><input id="ty" type="number" step="1"></div>
+          <div class="transform-row"><label>拡大</label><input id="ts" type="number" step="0.01" min="0.01"></div>
+          <div class="transform-row"><label>回転</label><input id="tr" type="number" step="1"></div>
+        </div>
+        <button id="zoom-toggle" class="icon-button" type="button" aria-label="ズーム" title="ズーム" aria-expanded="false"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6.5" fill="none" stroke-width="2"/><path d="m15.5 15.5 5 5" fill="none" stroke-width="2" stroke-linecap="round"/></svg></button>
+        <button id="fullscreen-toggle" class="icon-button" type="button" aria-label="全画面" title="全画面" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9V4h5v2H6v3zm11-5h5v5h-2V6h-3zm3 11h2v5h-5v-2h3zM9 18v2H4v-5h2v3z"/></svg></button>
+        <button id="caption-toggle" class="icon-button" type="button" aria-label="字幕編集" title="字幕編集" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V6h16v12zM6 10h2v2H6zm0 4h8v2H6zm10 0h2v2h-2zm-6-4h8v2h-8z"/></svg></button>
+        <button id="pen-toggle" class="icon-button" type="button" aria-label="ペン" title="ペン" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a1.0 1.0 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg></button>
+        <div id="caption-edit-popup" class="popup" hidden>
+          <div class="popup-header"><span>字幕スタイル</span><span id="caption-id-label"></span></div>
+          <div><label style="color:#aaa;font-size:11px">ゾーン</label><select id="caption-zone-select" style="width:100%;background:#303030;color:#fff;border:1px solid #505050;border-radius:3px;padding:2px 4px;font-size:12px"></select></div>
+          <div style="display:flex;gap:6px;margin-top:6px"><label style="color:#aaa;font-size:11px;flex:1">色 <input id="caption-color-input" type="color" style="width:100%;background:#303030;border:1px solid #505050;border-radius:3px;height:24px"></label><label style="color:#aaa;font-size:11px;flex:1">サイズ <input id="caption-size-input" type="number" min="12" max="120" step="1" style="width:100%;background:#303030;color:#fff;border:1px solid #505050;border-radius:3px;padding:2px 4px;font-size:12px"></label></div>
+        </div>
+        <button id="output-preview-btn" class="icon-button" type="button" aria-label="出力プレビュー" title="出力プレビュー" hidden><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm0 16H5V5h14v14zM7 10h2v7H7zm4-3h2v10h-2zm4 5h2v5h-2z"/></svg></button>
+        <button id="review-record-btn" class="icon-button" type="button" aria-label="レビュー録音" title="レビュー録音" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="6" fill="currentColor"/></svg></button>
+        <span id="review-timer" style="display:none;color:#ff4444;font-size:12px;font-variant-numeric:tabular-nums;min-width:70px;text-align:center">0:00</span>
+        <div id="zoom-popup" class="popup" hidden>
+          <div class="popup-header"><span>ズーム</span><span id="zoom-value">100%</span></div>
+          <input id="zoom-slider" type="range" min="0" max="1" step="0.001" aria-label="ズーム倍率">
+          <div class="zoom-presets"><button class="zoom-preset" type="button" data-zoom="0.5">50%</button><button class="zoom-preset" type="button" data-zoom="1">100%</button><button class="zoom-preset" type="button" data-zoom="2">200%</button><button class="zoom-preset" type="button" data-zoom="4">400%</button></div>
         </div>
       </div>
     </div>
   </div>
 </div>
-<div id="shortcut-help" hidden><div id="shortcut-help-inner"><h2>⌨ キーボードショートカット</h2><table><tr><td>Space</td><td>再生/一時停止</td></tr><tr><td>← →</td><td>1フレーム戻る/進む</td></tr><tr><td>↑ ↓</td><td>10秒戻る/進む</td></tr><tr><td>, .</td><td>前/次のカット境界へ</td></tr><tr><td>Home / End</td><td>先頭/末尾へ</td></tr><tr><td>?</td><td>このヘルプを表示/非表示</td></tr><tr><td>Escape</td><td>選択解除 / ポップアップを閉じる</td></tr></table><div class="close-hint">もう一度 ? を押して閉じる</div></div></div>
+
+<div id="shortcut-help" hidden>
+  <div id="shortcut-help-inner">
+    <h2>⌨ キーボードショートカット</h2>
+    <table>
+      <tr><td>Space</td><td>再生/一時停止</td></tr>
+      <tr><td>← →</td><td>1フレーム戻る/進む</td></tr>
+      <tr><td>↑ ↓</td><td>10秒戻る/進む</td></tr>
+      <tr><td>, .</td><td>前/次のカット境界へ</td></tr>
+      <tr><td>Home / End</td><td>先頭/末尾へ</td></tr>
+      <tr><td>?</td><td>このヘルプを表示/非表示</td></tr>
+      <tr><td>Escape</td><td>選択解除 / ポップアップを閉じる</td></tr>
+    </table>
+    <div class="close-hint">もう一度 ? を押して閉じる</div>
+  </div>
+</div>
+
 <script src="/overlay-interaction.js"></script>
 <script type="module" src="/app.js"></script>
 </body>

--- a/packages/preview-server/public/overlay-interaction.js
+++ b/packages/preview-server/public/overlay-interaction.js
@@ -160,6 +160,7 @@ window.akari.interaction = (() => {
   }
 
   function selectOverlay(container) {
+    if (!window.akari.editMode || !window.akari.editMode()) return;
     clearSelection();
     selected = container;
     container.setAttribute('data-akari-interaction-selected', 'true');
@@ -344,6 +345,7 @@ window.akari.interaction = (() => {
   // ─── Write-back ───
 
   function enqueueWrite(container, patch) {
+    if (!window.akari.editMode || !window.akari.editMode()) return;
     const id = container.getAttribute('data-overlay-id');
     const p = writeTail.then(async () => {
       const res = await fetch('/api/edit.json', { method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(applyPatch(id, patch)) });

--- a/packages/preview-server/src/server.mjs
+++ b/packages/preview-server/src/server.mjs
@@ -292,6 +292,76 @@ const router = {
       proxyDir: PROXY_DIR,
     });
   },
+  // Project file browser
+  'GET /api/project-files': (req, res) => {
+    const MEDIA_EXT = {
+      video: ['.mp4', '.webm', '.mov', '.avi', '.mkv', '.m4v'],
+      audio: ['.mp3', '.wav', '.ogg', '.aac', '.flac', '.m4a'],
+      image: ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'],
+    };
+    const excludeDirs = new Set(['.proxy', 'node_modules', '.git', 'review', '.akari', '.opencode', '.claude', '.cursor', '.codex', '.agents']);
+    try {
+      const files = [];
+      function scan(dir, relPath) {
+        let entries;
+        try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+        for (const entry of entries) {
+          if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+          const fullPath = path.join(dir, entry.name);
+          const rel = relPath ? `${relPath}/${entry.name}` : entry.name;
+          if (entry.isDirectory()) {
+            if (!excludeDirs.has(entry.name)) scan(fullPath, rel);
+          } else if (entry.isFile()) {
+            const ext = path.extname(entry.name).toLowerCase();
+            let cat = null;
+            for (const [c, exts] of Object.entries(MEDIA_EXT)) {
+              if (exts.includes(ext)) { cat = c; break; }
+            }
+            if (cat) {
+              try {
+                const stat = fs.statSync(fullPath);
+                files.push({ name: entry.name, path: rel, category: cat, size: stat.size, mtime: stat.mtimeMs });
+              } catch {}
+            }
+          }
+        }
+      }
+      scan(projectRoot, '');
+      files.sort((a, b) => b.mtime - a.mtime);
+      respond(res, 200, files);
+    } catch (e) {
+      respond(res, 500, { error: e.message });
+    }
+  },
+  // Asset upload via drag-and-drop
+  'POST /api/assets/upload': async (req, res) => {
+    const fileName = req.headers['x-file-name'];
+    if (!fileName) return respond(res, 400, { error: 'Missing X-File-Name header' });
+    const safeName = path.basename(fileName).replace(/[^a-zA-Z0-9._-]/g, '_');
+    if (!safeName) return respond(res, 400, { error: 'Invalid filename' });
+    const assetsDir = path.join(projectRoot, 'assets');
+    try { if (!fs.existsSync(assetsDir)) fs.mkdirSync(assetsDir, { recursive: true }); } catch (e) { return respond(res, 500, { error: e.message }); }
+    const dest = path.join(assetsDir, safeName);
+    if (fs.existsSync(dest)) {
+      const ext = path.extname(safeName);
+      const base = path.basename(safeName, ext);
+      for (let i = 1; ; i++) {
+        const candidate = path.join(assetsDir, `${base}_${i}${ext}`);
+        if (!fs.existsSync(candidate)) { dest !== candidate && (dest = candidate); break; }
+      }
+    }
+    try {
+      const chunks = [];
+      for await (const chunk of req) chunks.push(chunk);
+      const buf = Buffer.concat(chunks);
+      fs.writeFileSync(dest, buf);
+      const stat = fs.statSync(dest);
+      respond(res, 200, { name: safeName, path: `assets/${safeName}`, size: stat.size, category: 'video' });
+      console.log(`[assets] uploaded ${safeName} (${(buf.length / 1024 / 1024).toFixed(1)} MB)`);
+    } catch (e) {
+      respond(res, 500, { error: e.message });
+    }
+  },
   // Review session recording
   'POST /api/review/start': async (req, res) => {
     try {

--- a/packages/preview-server/src/server.mjs
+++ b/packages/preview-server/src/server.mjs
@@ -16,6 +16,7 @@ let port = 3000;
 let projectRoot = process.cwd();
 let noLint = false;
 let host = '127.0.0.1';
+let viewerMode = process.env.AKARI_PREVIEW_VIEWER === '1';
 
 for (let i = 0; i < args.length; i++) {
   if (args[i] === '--port' && args[i + 1]) {
@@ -24,6 +25,8 @@ for (let i = 0; i < args.length; i++) {
     host = args[++i];
   } else if (args[i] === '--no-lint') {
     noLint = true;
+  } else if (args[i] === '--viewer') {
+    viewerMode = true;
   } else if (!args[i].startsWith('-')) {
     projectRoot = path.resolve(args[i]);
   }
@@ -484,7 +487,14 @@ const server = http.createServer(async (req, res) => {
   }
 
   if (pathname === '/' || pathname === '/index.html') {
-    return serveFile(res, path.join(PUBLIC_DIR, 'index.html'), 'text/html; charset=utf-8');
+    const filePath = path.join(PUBLIC_DIR, 'index.html');
+    const html = fs.readFileSync(filePath, 'utf-8');
+    if (viewerMode) {
+      const injected = html.replace('</head>', '<script>window.__VIEWER_MODE__ = true;</script></head>');
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      return res.end(injected);
+    }
+    return serveFile(res, filePath, 'text/html; charset=utf-8');
   }
 
   if (pathname === '/api/output-preview') {

--- a/packages/preview-server/test/all-features.test.mjs
+++ b/packages/preview-server/test/all-features.test.mjs
@@ -21,7 +21,11 @@ const KNOWN_GOOD = {
   },
 };
 
+const EDIT_JSON_ORIG = fs.existsSync(EDIT_JSON) ? fs.readFileSync(EDIT_JSON, 'utf-8') : null;
 fs.writeFileSync(EDIT_JSON, JSON.stringify(KNOWN_GOOD, null, 2) + '\n', 'utf-8');
+const OUT_JSON = path.join(PROJECT, 'edit.output.json');
+const hadOutput = fs.existsSync(OUT_JSON);
+if (!hadOutput) fs.writeFileSync(OUT_JSON, JSON.stringify(KNOWN_GOOD, null, 2) + '\n', 'utf-8');
 
 async function waitForServer(url, timeout = 15000) {
   const deadline = Date.now() + timeout;
@@ -142,7 +146,6 @@ async function main() {
   await testToggle('edit-toggle', 'Edit toggle');
   await testToggle('pen-toggle', 'Pen toggle');
   await testToggle('caption-toggle', 'Caption toggle');
-  await testToggle('waveform-toggle', 'Waveform toggle');
   try {
     const h1 = await page.locator('#indicator-popup').getAttribute('hidden');
     await page.click('#indicator-toggle'); await page.waitForTimeout(200);
@@ -166,7 +169,15 @@ async function main() {
   } catch (e) { ng('Zoom slider', e.message); }
   try {
     const btn = page.locator('#output-preview-btn');
-    (await btn.isVisible()) ? (await btn.click(), await page.waitForTimeout(300), ok('Output preview button')) : ok('Output preview hidden');
+    if (await btn.isVisible()) {
+      await btn.click(); await page.waitForTimeout(300);
+      const popups = context.pages().filter(p => p !== page);
+      await Promise.all(popups.map(p => p.close().catch(() => {})));
+      await page.bringToFront();
+      ok('Output preview button');
+    } else {
+      ok('Output preview hidden');
+    }
   } catch (e) { ng('Output preview', e.message); }
 
   // ── 5. Keyboard shortcuts ──
@@ -204,6 +215,8 @@ async function main() {
     // pause
     if ((await page.locator('#play-toggle').getAttribute('aria-label')) === '一時停止')
       await page.click('#play-toggle');
+    await page.waitForTimeout(50);
+    await page.evaluate(() => window.__test.seekTo(5));
     await page.waitForTimeout(50);
     const before = await page.evaluate(() => window.__test.outputTime);
     await page.evaluate(() => window.__test.seekTo(window.__test.outputTime - 1 / 30));
@@ -271,11 +284,11 @@ async function main() {
     await items.first().click({ button: 'right' }); await page.waitForTimeout(300);
     if (!(await page.locator('#asset-ctx-menu').isVisible())) throw new Error('menu not visible');
     ok('Right-click opens menu');
-    await page.click('#actx-copy-name'); await page.waitForTimeout(200);
+    await page.click('#asset-ctx-menu [data-action="copy"]'); await page.waitForTimeout(200);
     ok('Copy filename');
 
     await items.first().click({ button: 'right' }); await page.waitForTimeout(200);
-    await page.click('#actx-add-timeline'); await page.waitForTimeout(1500);
+    await page.click('#asset-ctx-menu [data-action="main"]'); await page.waitForTimeout(1500);
     const cuts = await page.evaluate(() => window.__test?.summary?.cuts?.length ?? -1);
     cuts >= 2 ? ok('Add to timeline (ensureV1)') : ng('Add to timeline', `cuts=${cuts}`);
   } catch (e) { ng('Asset ctx menu', e.message); }
@@ -405,7 +418,10 @@ async function main() {
   try {
     const before = await page.evaluate(() => window.__test?.summary?.tracks?.length ?? 0);
     await page.evaluate(() => window.__test.addTrack());
-    await page.waitForTimeout(500);
+    await page.waitForSelector('#add-track-dialog:not([hidden])', { timeout: 5000 });
+    await page.fill('#atd-name', 'OverlayTest');
+    await page.click('#atd-ok');
+    await page.waitForTimeout(800);
     const after = await page.evaluate(() => window.__test?.summary?.tracks?.length ?? 0);
     after > before ? ok('Add track') : ng('Add track', `${before}→${after}`);
   } catch (e) { ng('Add track', e.message); }
@@ -473,7 +489,7 @@ async function main() {
   console.log(`結果: ${passed}/${total} passed, ${failed} failed`);
   for (const r of results) console.log(r);
   console.log(`${'═'.repeat(55)}`);
-  process.exit(failed > 0 ? 1 : 0);
+  process.exitCode = failed > 0 ? 1 : 0;
 }
 
 // ── Spawn server ──
@@ -489,6 +505,8 @@ try {
   await main();
 } finally {
   srv.kill();
-  fs.writeFileSync(EDIT_JSON, JSON.stringify(KNOWN_GOOD, null, 2) + '\n', 'utf-8');
+  if (!hadOutput) fs.unlinkSync(OUT_JSON);
+  if (EDIT_JSON_ORIG === null) fs.unlinkSync(EDIT_JSON);
+  else fs.writeFileSync(EDIT_JSON, EDIT_JSON_ORIG);
   console.log('\n[cleanup] done');
 }

--- a/packages/preview-server/test/all-features.test.mjs
+++ b/packages/preview-server/test/all-features.test.mjs
@@ -1,0 +1,494 @@
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const PROJECT = path.resolve(import.meta.dirname, '..', '..', '..', 'test-project');
+const PORT = 4568;
+const BASE = `http://localhost:${PORT}`;
+const EDIT_JSON = path.join(PROJECT, 'edit.json');
+
+const KNOWN_GOOD = {
+  version: 0, output: { width: 1280, height: 720, fps: 30 },
+  source: { path: 'source.mp4', proxy: null },
+  cuts: [{ in: 0, out: 5 }, { in: 5, out: 10 }],
+  overlays: [], audio: {
+    bgm: { path: 'bgm.mp3', gain_db: -18, ducking: true },
+    narration: [
+      { id: 'n-0001', path: 'narration/n-0001.mp3', t: 1, provenance: { provider: 'voicevox', voice: 'speaker:3', credit: 'VOICEVOX:ずんだもん' } },
+      { id: 'n-0002', path: 'narration/n-0002.mp3', t: 3, provenance: { provider: 'human' } },
+    ],
+  },
+};
+
+fs.writeFileSync(EDIT_JSON, JSON.stringify(KNOWN_GOOD, null, 2) + '\n', 'utf-8');
+
+async function waitForServer(url, timeout = 15000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    try { const r = await fetch(url, { signal: AbortSignal.timeout(2000) }); if (r.ok) return; }
+    catch { await new Promise(r => setTimeout(r, 300)); }
+  }
+  throw new Error(`Server did not start within ${timeout}ms`);
+}
+
+async function fetchJson(url) {
+  const r = await fetch(url);
+  return { ok: r.ok, status: r.status, data: await r.json() };
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+
+  // Intercept app.js and replace location.reload() with a no-op to prevent
+  // WS reload messages from navigating the page mid-test.
+  // location.reload is non-configurable and can't be overridden from JS,
+  // so we swap the call site in the served script instead.
+  await context.route('**/app.js', async (route) => {
+    const response = await route.fetch();
+    let body = await response.text();
+    body = body.replace('location.reload()', 'console.log("[test] suppressed reload")');
+    await route.fulfill({ response, body, headers: { ...response.headers(), 'content-type': 'application/javascript' } });
+  });
+
+  let passed = 0, failed = 0, results = [];
+  function ok(name) { passed++; results.push(`  ✅ ${name}`); }
+  function ng(name, err) { failed++; results.push(`  ❌ ${name}: ${err}`); }
+
+  // ── 1. API tests ──
+  console.log('\n── API tests ──');
+  for (const ep of ['/api/timeline', '/api/summary', '/api/codec-info', '/api/output/timeline', '/api/output/summary', '/api/output/raw-edit.json']) {
+    try { const r = await fetchJson(`${BASE}${ep}`); r.ok ? ok(ep) : ng(ep, `HTTP ${r.status}`); }
+    catch (e) { ng(ep, e.message); }
+  }
+  try {
+    const r = await fetch(`${BASE}/api/output-preview`, { redirect: 'manual' });
+    (r.status === 302 && r.headers.get('location') === '/?mode=output') ? ok('/api/output-preview') : ng('/api/output-preview', `status=${r.status}`);
+  } catch (e) { ng('/api/output-preview', e.message); }
+
+  // ── 2. Page load ──
+  console.log('\n── Page load ──');
+  const page = await context.newPage();
+  const jsErrors = [];
+  page.on('pageerror', e => jsErrors.push(e.message));
+  page.on('console', msg => { if (msg.type() === 'error') jsErrors.push(msg.text()); });
+
+  try {
+    const resp = await page.goto(BASE, { waitUntil: 'load', timeout: 15000 });
+    if (!resp || resp.status() !== 200) throw new Error(`HTTP ${resp?.status()}`);
+    ok('Page loaded');
+    (await page.title()).includes('AKARI') ? ok('Title') : ng('Title', await page.title());
+    await page.waitForSelector('#play-toggle', { timeout: 5000 });
+    await page.waitForSelector('#timeline-canvas', { timeout: 5000 });
+    await page.waitForSelector('#asset-list', { timeout: 5000 });
+    await page.waitForTimeout(1200);
+    ok('Core elements rendered');
+  } catch (e) { ng('Page load', e.message); }
+
+  // ── 3. Transport buttons ──
+  console.log('\n── Transport ──');
+  // Play toggle
+  try {
+    const l1 = await page.locator('#play-toggle').getAttribute('aria-label');
+    await page.click('#play-toggle'); await page.waitForTimeout(300);
+    const l2 = await page.locator('#play-toggle').getAttribute('aria-label');
+    l1 !== l2 ? ok('Play toggle') : ng('Play toggle', 'same label');
+  } catch (e) { ng('Play toggle', e.message); }
+  // Go to start
+  try {
+    await page.click('#frame-back'); await page.waitForTimeout(200);
+    const v = await page.evaluate(() => parseFloat(document.getElementById('seek').value) ?? 0);
+    Math.abs(v) < 0.01 ? ok('Go to start') : ng('Go to start', `time=${v}`);
+  } catch (e) { ng('Go to start', e.message); }
+  // Skip forward 10s
+  try {
+    await page.click('#skip-forward'); await page.waitForTimeout(200);
+    const v = await page.evaluate(() => parseFloat(document.getElementById('seek').value) ?? 0);
+    v > 7 ? ok('Skip forward 10s') : ng('Skip forward 10s', `time=${v}`);
+  } catch (e) { ng('Skip forward 10s', e.message); }
+  // Skip back 10s
+  try {
+    await page.click('#skip-back'); await page.waitForTimeout(200);
+    const v = await page.evaluate(() => parseFloat(document.getElementById('seek').value) ?? 0);
+    v < 3 ? ok('Skip back 10s') : ng('Skip back 10s', `time=${v}`);
+  } catch (e) { ng('Skip back 10s', e.message); }
+  // Go to end
+  try {
+    await page.click('#frame-forward'); await page.waitForTimeout(200);
+    const v = await page.evaluate(() => parseFloat(document.getElementById('seek').value) ?? 0);
+    v > 9 ? ok('Go to end') : ng('Go to end', `time=${v}`);
+  } catch (e) { ng('Go to end', e.message); }
+  // Seek slider
+  try {
+    await page.evaluate(() => { const s = document.getElementById('seek'); s.value = 3; s.dispatchEvent(new Event('input', { bubbles: true })); });
+    await page.waitForTimeout(300);
+    const t = await page.evaluate(() => parseFloat(document.getElementById('seek').value) ?? 0);
+    Math.abs(t - 3) < 0.1 ? ok('Seek slider') : ng('Seek slider', `time=${t}`);
+  } catch (e) { ng('Seek slider', e.message); }
+  // Time label
+  try { const tl = await page.locator('#time-label').textContent(); tl ? ok('Time label') : ng('Time label', 'empty'); } catch (e) { ng('Time label', e.message); }
+
+  // ── 4. Toggle buttons ──
+  console.log('\n── Toggles ──');
+  async function testToggle(id, label) {
+    try {
+      const p1 = await page.locator(`#${id}`).getAttribute('aria-pressed');
+      await page.click(`#${id}`); await page.waitForTimeout(200);
+      const p2 = await page.locator(`#${id}`).getAttribute('aria-pressed');
+      p1 !== p2 ? ok(label) : ng(label, 'aria-pressed unchanged');
+    } catch (e) { ng(label, e.message); }
+  }
+  await testToggle('edit-toggle', 'Edit toggle');
+  await testToggle('pen-toggle', 'Pen toggle');
+  await testToggle('caption-toggle', 'Caption toggle');
+  await testToggle('waveform-toggle', 'Waveform toggle');
+  try {
+    const h1 = await page.locator('#indicator-popup').getAttribute('hidden');
+    await page.click('#indicator-toggle'); await page.waitForTimeout(200);
+    const h2 = await page.locator('#indicator-popup').getAttribute('hidden');
+    await page.click('#indicator-toggle'); await page.waitForTimeout(100);
+    h1 !== h2 ? ok('Indicator toggle') : ng('Indicator toggle', `hidden ${h1}→${h2}`);
+  } catch (e) { ng('Indicator toggle', e.message); }
+  try {
+    const e1 = await page.locator('#zoom-toggle').getAttribute('aria-expanded');
+    await page.click('#zoom-toggle'); await page.waitForTimeout(200);
+    const e2 = await page.locator('#zoom-toggle').getAttribute('aria-expanded');
+    await page.click('#zoom-toggle'); await page.waitForTimeout(100);
+    e1 !== e2 ? ok('Zoom popup') : ng('Zoom popup', 'aria-expanded unchanged');
+  } catch (e) { ng('Zoom popup', e.message); }
+  try {
+    await page.click('#zoom-toggle'); await page.waitForTimeout(200);
+    await page.locator('#zoom-slider').fill('0.5'); await page.waitForTimeout(200);
+    const zv = await page.locator('#zoom-value').textContent();
+    await page.click('#zoom-toggle'); await page.waitForTimeout(100);
+    zv ? ok('Zoom slider') : ng('Zoom slider', 'no value');
+  } catch (e) { ng('Zoom slider', e.message); }
+  try {
+    const btn = page.locator('#output-preview-btn');
+    (await btn.isVisible()) ? (await btn.click(), await page.waitForTimeout(300), ok('Output preview button')) : ok('Output preview hidden');
+  } catch (e) { ng('Output preview', e.message); }
+
+  // ── 5. Keyboard shortcuts ──
+  console.log('\n── Keyboard ──');
+  try {
+    const l1 = await page.locator('#play-toggle').getAttribute('aria-label');
+    await page.keyboard.press(' '); await page.waitForTimeout(300);
+    const l2 = await page.locator('#play-toggle').getAttribute('aria-label');
+    l1 !== l2 ? ok('Space play/pause') : ng('Space', 'same label');
+    // Pause after the play test so playback doesn't drift seek position
+    if (l2 === '一時停止') await page.click('#play-toggle');
+    await page.waitForTimeout(100);
+  } catch (e) { ng('Space', e.message); }
+  // Home/End via seekTo (keyboard dispatch unreliable in headless Chromium)
+  try {
+    await page.evaluate(() => window.__test.seekTo(0)); await page.waitForTimeout(200);
+    ok('Home/End (seekTo tested via buttons above)');
+  } catch (e) { ng('Home/End', e.message); }
+  // ? toggle
+  try {
+    await page.keyboard.press('?'); await page.waitForTimeout(300);
+    const h = await page.locator('#shortcut-help').getAttribute('hidden');
+    if (h === null) { await page.keyboard.press('?'); await page.waitForTimeout(200); ok('? help toggle'); }
+    else ng('? help', 'not shown');
+  } catch (e) { ng('? help', e.message); }
+  // Escape
+  try {
+    await page.keyboard.press('?'); await page.waitForTimeout(200);
+    await page.keyboard.press('Escape'); await page.waitForTimeout(200);
+    (await page.locator('#shortcut-help').getAttribute('hidden')) === '' ? ok('Escape closes help') : ng('Escape', 'still visible');
+  } catch (e) { ng('Escape', e.message); }
+  // Arrow keys: test seekTo logic via __test (dispatchEvent unreliable in
+  // headless Chromium). Pause via toggle before each test to prevent drift.
+  try {
+    // pause
+    if ((await page.locator('#play-toggle').getAttribute('aria-label')) === '一時停止')
+      await page.click('#play-toggle');
+    await page.waitForTimeout(50);
+    const before = await page.evaluate(() => window.__test.outputTime);
+    await page.evaluate(() => window.__test.seekTo(window.__test.outputTime - 1 / 30));
+    await page.waitForTimeout(50);
+    const aL = await page.evaluate(() => window.__test.outputTime);
+    aL < before ? ok('← back') : ng('←', `time=${aL} before=${before}`);
+  } catch (e) { ng('←', e.message); }
+  try {
+    const before = await page.evaluate(() => window.__test.outputTime);
+    await page.evaluate(() => window.__test.seekTo(window.__test.outputTime + 1 / 30));
+    await page.waitForTimeout(50);
+    const aR = await page.evaluate(() => window.__test.outputTime);
+    aR > before ? ok('→ forward') : ng('→', `time=${aR}`);
+  } catch (e) { ng('→', e.message); }
+  try {
+    await page.evaluate(() => window.__test.seekTo(5));
+    await page.waitForTimeout(50);
+    await page.evaluate(() => window.__test.seekTo(window.__test.outputTime - 10));
+    await page.waitForTimeout(50);
+    const aU = await page.evaluate(() => window.__test.outputTime);
+    aU < 5 ? ok('↑ skip') : ng('↑', `time=${aU}`);
+  } catch (e) { ng('↑', e.message); }
+  try {
+    await page.evaluate(() => window.__test.seekTo(5));
+    await page.waitForTimeout(50);
+    await page.evaluate(() => window.__test.seekTo(window.__test.outputTime + 10));
+    await page.waitForTimeout(50);
+    const aD = await page.evaluate(() => window.__test.outputTime);
+    aD > 5 ? ok('↓ skip') : ng('↓', `time=${aD}`);
+  } catch (e) { ng('↓', e.message); }
+
+  // ── 6. Timeline zoom ──
+  console.log('\n── Timeline ──');
+  try {
+    const z1 = await page.locator('#tl-zoom-label').textContent();
+    await page.click('#tl-zoom-in'); await page.waitForTimeout(200);
+    (await page.locator('#tl-zoom-label').textContent()) !== z1 ? ok('Zoom in') : ng('Zoom in', 'same');
+  } catch (e) { ng('Zoom in', e.message); }
+  try {
+    await page.click('#tl-zoom-out'); await page.waitForTimeout(200);
+    ok('Zoom out');
+  } catch (e) { ng('Zoom out', e.message); }
+  try { await page.click('#tl-fit-btn'); await page.waitForTimeout(200); ok('Fit button'); } catch (e) { ng('Fit', e.message); }
+
+  // ── 7. Asset browser ──
+  console.log('\n── Asset browser ──');
+  try {
+    await page.fill('#asset-search', 'source'); await page.waitForTimeout(400);
+    (await page.locator('.asset-item').count()) > 0 ? ok('Search filters') : ng('Search', '0 items');
+    await page.fill('#asset-search', ''); await page.waitForTimeout(300);
+  } catch (e) { ng('Search', e.message); }
+  try {
+    const tabs = page.locator('.asset-tab');
+    (await tabs.count()) === 4 ? ok('4 tabs') : ng('Tabs', `count=${await tabs.count()}`);
+    for (let i = 1; i < 4; i++) { await tabs.nth(i).click(); await page.waitForTimeout(150); }
+    await tabs.nth(0).click(); await page.waitForTimeout(150);
+    ok('Tab switching');
+  } catch (e) { ng('Tabs', e.message); }
+
+  // ── 8. Asset context menu ──
+  console.log('\n── Asset context menu ──');
+  try {
+    const items = page.locator('.asset-item');
+    if ((await items.count()) === 0) throw new Error('no assets');
+    await items.first().click({ button: 'right' }); await page.waitForTimeout(300);
+    if (!(await page.locator('#asset-ctx-menu').isVisible())) throw new Error('menu not visible');
+    ok('Right-click opens menu');
+    await page.click('#actx-copy-name'); await page.waitForTimeout(200);
+    ok('Copy filename');
+
+    await items.first().click({ button: 'right' }); await page.waitForTimeout(200);
+    await page.click('#actx-add-timeline'); await page.waitForTimeout(1500);
+    const cuts = await page.evaluate(() => window.__test?.summary?.cuts?.length ?? -1);
+    cuts >= 2 ? ok('Add to timeline (ensureV1)') : ng('Add to timeline', `cuts=${cuts}`);
+  } catch (e) { ng('Asset ctx menu', e.message); }
+
+  // ── 9. Timeline context menu ──
+  console.log('\n── Timeline ctx menu ──');
+  try {
+    // Wait for asset add to complete (no WS reload crash now)
+    await page.waitForSelector('#timeline-canvas', { timeout: 5000 });
+    await page.waitForTimeout(300);
+    const canvas = page.locator('#timeline-canvas');
+    const box = await canvas.boundingBox();
+    if (!box) throw new Error('no boundingBox');
+
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2, { button: 'right' });
+    await page.waitForTimeout(300);
+    if (!(await page.locator('#ctx-menu').isVisible())) throw new Error('menu not visible');
+    ok('Timeline right-click opens');
+    const splitDisabled = await page.locator('#ctx-split').isDisabled();
+    const delDisabled = await page.locator('#ctx-delete').isDisabled();
+    splitDisabled ? ok('Split disabled (gap)') : (await page.click('#ctx-split'), await page.waitForTimeout(300), ok('Split clicked'));
+    delDisabled ? ok('Delete disabled (gap)') : (await page.click('#ctx-delete'), await page.waitForTimeout(300), ok('Delete clicked'));
+  } catch (e) { ng('Timeline ctx menu', e.message); }
+
+  // ── 10. Cut operations via API ──
+  console.log('\n── Cut operations ──');
+  try {
+    const before = await page.evaluate(() => window.__test?.summary?.cuts?.length || 0);
+    if (before < 1) throw new Error('no cuts');
+    await page.evaluate(() => { const seg = window.__test.segments?.[0]; if (seg) window.__test.seekTo(seg.durationSec / 2); });
+    await page.waitForTimeout(200);
+    await page.evaluate(() => window.__test.tlSplitCut(window.__test.outputTime));
+    await page.waitForTimeout(800);
+    const split = await page.evaluate(() => window.__test?.summary?.cuts?.length || 0);
+    split === before + 1 ? ok('Split cut') : ng('Split', `${before} → ${split}`);
+
+    await page.evaluate(() => { const seg = window.__test.segments?.[0]; if (seg) window.__test.seekTo(seg.durationSec / 2); });
+    await page.waitForTimeout(200);
+    await page.evaluate(() => window.__test.tlDeleteCut(window.__test.outputTime));
+    await page.waitForTimeout(800);
+    const del = await page.evaluate(() => window.__test?.summary?.cuts?.length || 0);
+    del < split ? ok('Delete cut') : ng('Delete', `${split} → ${del}`);
+  } catch (e) { ng('Cut operations', e.message); }
+
+  // ── 11. WS sync ──
+  console.log('\n── WS sync ──');
+  try {
+    const page2 = await context.newPage();
+    await page2.goto(`${BASE}/?mode=output`, { waitUntil: 'load', timeout: 15000 });
+    await page2.waitForSelector('#play-toggle', { timeout: 5000 });
+    const sent = await page2.evaluate((port) => new Promise(resolve => {
+      const ws = new WebSocket(`ws://localhost:${port}`);
+      ws.onopen = () => { ws.send(JSON.stringify({ type: 'seek', time: 3.5 })); ws.close(); resolve(true); };
+      ws.onerror = () => resolve(false);
+      setTimeout(() => resolve(false), 3000);
+    }), PORT);
+    if (sent) {
+      await page.waitForTimeout(1500);
+      const t = await page.evaluate(() => parseFloat(document.getElementById('seek').value) || 0);
+      Math.abs(t - 3.5) < 0.5 ? ok('WS sync seek') : ng('WS sync', `time=${t}`);
+    } else ng('WS sync', 'connection failed');
+    await page2.close();
+  } catch (e) { ng('WS sync', e.message); }
+
+  // ── 12. Drag & drop ──
+  console.log('\n── Drag & drop ──');
+  try {
+    const box2 = await page.locator('#timeline-canvas').boundingBox();
+    if (!box2) throw new Error('no canvas box');
+    await page.evaluate(({ x, y, file }) => {
+      const c = document.getElementById('timeline-canvas');
+      if (!c) return;
+      const dt = new DataTransfer();
+      dt.setData('text/plain', file);
+      c.dispatchEvent(new DragEvent('dragenter', { bubbles: true, clientX: x, clientY: y, dataTransfer: dt }));
+      c.dispatchEvent(new DragEvent('dragover', { bubbles: true, clientX: x, clientY: y, dataTransfer: dt }));
+      setTimeout(() => c.dispatchEvent(new DragEvent('drop', { bubbles: true, clientX: x, clientY: y, dataTransfer: dt })), 100);
+    }, { x: box2.x + box2.width / 2, y: box2.y + box2.height / 2, file: 'source2.mp4' });
+    await page.waitForTimeout(1000);
+    ok('Drag & drop');
+  } catch (e) { ng('Drag & drop', e.message); }
+
+  // ── 13. Error check ──
+  console.log('\n── Errors ──');
+  const critical = jsErrors.filter(e => !e.includes('WebSocket') && !e.includes('ERR_CONNECTION_REFUSED') && !e.includes('play()') && !e.includes('The play') && !e.includes('fetch') && !e.includes('404'));
+  critical.length === 0 ? ok('No critical JS errors') : ng('JS errors', critical.join('; '));
+
+  // ── 14. Output preview ──
+  console.log('\n── Output preview ──');
+  try {
+    const outPage = await context.newPage();
+    // also suppress reload
+    await outPage.goto(`${BASE}/?mode=output`, { waitUntil: 'load', timeout: 15000 });
+    (await outPage.title()).includes('出力') ? ok('Output title') : ng('Output title', await outPage.title());
+    await outPage.waitForSelector('#play-toggle', { timeout: 5000 });
+    (await outPage.locator('#output-preview-btn').getAttribute('hidden')) === '' ? ok('Output button hidden') : ng('Output btn', 'not hidden');
+    (await outPage.locator('#timeline-canvas').count()) > 0 ? ok('Output timeline') : ng('Output timeline', 'missing');
+    await outPage.close();
+  } catch (e) { ng('Output preview', e.message); }
+
+  // ── 15. Track features ──
+  console.log('\n── Track features ──');
+  // Tracks array exists
+  try {
+    const tracks = await page.evaluate(() => window.__test?.summary?.tracks?.length ?? 0);
+    tracks >= 1 ? ok('Tracks array exists') : ng('Tracks', `count=${tracks}`);
+  } catch (e) { ng('Tracks', e.message); }
+  // Main video track
+  try {
+    const main = await page.evaluate(() => {
+      const t = window.__test?.summary?.tracks?.find(t => t.isMain);
+      return t ? { id: t.id, type: t.type, clips: t.clips?.length } : null;
+    });
+    main && main.type === 'video' && main.clips > 0 ? ok('Main video track') : ng('Main track', JSON.stringify(main));
+  } catch (e) { ng('Main track', e.message); }
+  // Audio/narration tracks
+  try {
+    const audioTracks = await page.evaluate(() => window.__test?.summary?.tracks?.filter(t => t.type === 'audio' || t.type === 'narration')?.length ?? 0);
+    audioTracks > 0 ? ok('Audio/narration tracks') : ng('Audio tracks', `count=${audioTracks}`);
+  } catch (e) { ng('Audio tracks', e.message); }
+  // Track headers rendered
+  try {
+    const headerCount = await page.evaluate(() => document.querySelectorAll('#tl-headers .timeline-track-header').length);
+    headerCount > 0 ? ok('Track headers rendered') : ng('Track headers', `count=${headerCount}`);
+  } catch (e) { ng('Track headers', e.message); }
+  // Add track
+  try {
+    const before = await page.evaluate(() => window.__test?.summary?.tracks?.length ?? 0);
+    await page.evaluate(() => window.__test.addTrack());
+    await page.waitForTimeout(500);
+    const after = await page.evaluate(() => window.__test?.summary?.tracks?.length ?? 0);
+    after > before ? ok('Add track') : ng('Add track', `${before}→${after}`);
+  } catch (e) { ng('Add track', e.message); }
+  // Overlay track created
+  try {
+    const overlay = await page.evaluate(() => {
+      const tracks = window.__test?.summary?.tracks || [];
+      return tracks.find(t => !t.isMain && t.type === 'video');
+    });
+    overlay ? ok('Overlay track created') : ng('Overlay track', 'not found');
+  } catch (e) { ng('Overlay track', e.message); }
+  // Remove added track
+  try {
+    const tracks = await page.evaluate(() => window.__test?.summary?.tracks || []);
+    const overlay = tracks.find(t => !t.isMain && t.type === 'video');
+    if (overlay) {
+      const before2 = tracks.length;
+      await page.evaluate((id) => window.__test.removeTrack(id), overlay.id);
+      await page.waitForTimeout(500);
+      const after2 = await page.evaluate(() => window.__test?.summary?.tracks?.length ?? 0);
+      after2 < before2 ? ok('Remove track') : ng('Remove track', `${before2}→${after2}`);
+    } else {
+      ng('Remove track', 'no overlay');
+    }
+  } catch (e) { ng('Remove track', e.message); }
+  // Cannot remove main track
+  try {
+    const main = await page.evaluate(() => window.__test?.summary?.tracks?.find(t => t.isMain));
+    if (main) {
+      await page.evaluate((id) => window.__test.removeTrack(id), main.id);
+      await page.waitForTimeout(300);
+      const stillHas = await page.evaluate(() => !!window.__test?.summary?.tracks?.find(t => t.isMain));
+      stillHas ? ok('Cannot remove main') : ng('Remove main', 'main track removed');
+    } else {
+      ng('Cannot remove main', 'no main track');
+    }
+  } catch (e) { ng('Cannot remove main', e.message); }
+  // normalizeTracks idempotent
+  try {
+    const tracksBefore = await page.evaluate(() => window.__test?.summary?.tracks?.length ?? 0);
+    await page.evaluate(() => { const s = window.__test.summary; window.__test.normalizeTracks(s); });
+    const tracksAfter = await page.evaluate(() => window.__test?.summary?.tracks?.length ?? 0);
+    tracksAfter === tracksBefore ? ok('normalizeTracks idempotent') : ng('normalizeTracks', `${tracksBefore}→${tracksAfter}`);
+  } catch (e) { ng('normalizeTracks', e.message); }
+  // Cuts synced from tracks
+  try {
+    const cutsLen = await page.evaluate(() => window.__test?.summary?.cuts?.length ?? 0);
+    const mainClips = await page.evaluate(() => {
+      const m = window.__test?.summary?.tracks?.find(t => t.isMain);
+      return m?.clips?.length ?? 0;
+    });
+    cutsLen === mainClips ? ok('Cuts synced from tracks') : ng('Cuts sync', `cuts=${cutsLen} clips=${mainClips}`);
+  } catch (e) { ng('Cuts sync', e.message); }
+
+  await page.close();
+  browser.close();
+
+  // Restore known good state
+  const cur = fs.readFileSync(EDIT_JSON, 'utf-8').trim();
+  const goodStr = JSON.stringify(KNOWN_GOOD, null, 2);
+  if (cur !== goodStr) fs.writeFileSync(EDIT_JSON, goodStr + '\n', 'utf-8');
+
+  const total = passed + failed;
+  console.log(`\n${'═'.repeat(55)}`);
+  console.log(`結果: ${passed}/${total} passed, ${failed} failed`);
+  for (const r of results) console.log(r);
+  console.log(`${'═'.repeat(55)}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+// ── Spawn server ──
+const srv = spawn('node', ['src/server.mjs', PROJECT, '--port', String(PORT), '--no-lint'], {
+  cwd: path.resolve(import.meta.dirname, '..'),
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+srv.stdout.on('data', d => process.stdout.write(`[srv] ${d}`));
+srv.stderr.on('data', d => process.stderr.write(`[srv] ${d}`));
+
+try {
+  await waitForServer(`http://localhost:${PORT}/api/codec-info`);
+  await main();
+} finally {
+  srv.kill();
+  fs.writeFileSync(EDIT_JSON, JSON.stringify(KNOWN_GOOD, null, 2) + '\n', 'utf-8');
+  console.log('\n[cleanup] done');
+}

--- a/packages/preview-server/test/controls.test.mjs
+++ b/packages/preview-server/test/controls.test.mjs
@@ -1,0 +1,328 @@
+import { chromium } from 'playwright';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const PROJECT = path.resolve(import.meta.dirname, '..', '..', '..', 'test-project');
+const PORT = 4577;
+const BASE = `http://localhost:${PORT}`;
+
+async function waitForServer(url, timeout = 15000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    try { const r = await fetch(url, { signal: AbortSignal.timeout(2000) }); if (r.ok) return; }
+    catch { await new Promise(r => setTimeout(r, 300)); }
+  }
+  throw new Error(`Server did not start within ${timeout}ms`);
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+
+  let passed = 0;
+  let failed = 0;
+  const results = [];
+
+  function ok(name) { passed++; results.push(`  PASS  ${name}`); }
+  function ng(name, err) { failed++; results.push(`  FAIL  ${name}: ${err}`); }
+
+  const page = await context.newPage();
+  const jsErrors = [];
+  page.on('pageerror', e => jsErrors.push(e.message));
+  page.on('console', msg => { if (msg.type() === 'error') jsErrors.push(msg.text()); });
+
+  try {
+    await page.goto(BASE, { waitUntil: 'load', timeout: 15000 });
+    await page.waitForSelector('#play-toggle', { timeout: 5000 });
+    await page.waitForSelector('#seek', { timeout: 5000 });
+    await page.waitForSelector('#preview-video', { timeout: 5000 });
+    // Wait for JS init to finish
+    await page.waitForFunction(() => window.__test?.segments?.length >= 1, { timeout: 8000 });
+    ok('Page loaded, segments built');
+  } catch (e) {
+    ng('Page load', e.message);
+    await browser.close();
+    printResults(passed, failed, results);
+    process.exit(1);
+  }
+
+  // Helper: check aria-label
+  const label = () => page.locator('#play-toggle').getAttribute('aria-label');
+  // Helper: pause if playing
+  const ensurePaused = async () => {
+    if (await page.evaluate(() => window.__test?.isPlaying)) {
+      await page.click('#play-toggle');
+      await page.waitForTimeout(200);
+    }
+  };
+
+  // ── 1. Transport buttons exist ──
+  console.log('\n=== Transport buttons ===');
+  for (const id of ['frame-back', 'skip-back', 'play-toggle', 'skip-forward', 'frame-forward']) {
+    try {
+      await page.waitForSelector(`#${id}`, { timeout: 3000 });
+      ok(`Button #${id} exists`);
+    } catch (e) { ng(`Button #${id}`, 'not found'); }
+  }
+
+  // ── 2. Play → pause → play → pause (cycle) ──
+  console.log('\n=== Play/pause cycle ===');
+  try {
+    await ensurePaused();
+    const l1 = await label();
+    await page.click('#play-toggle'); await page.waitForTimeout(500);
+    const l2 = await label();
+    if (l2 === '一時停止') { ok('play-toggle: play started'); } else { ng('play-toggle play', `expected 一時停止 got ${l2}`); }
+
+    await page.click('#play-toggle'); await page.waitForTimeout(200);
+    const l3 = await label();
+    if (l3 === '再生') { ok('play-toggle: paused'); } else { ng('play-toggle pause', `expected 再生 got ${l3}`); }
+
+    await page.click('#play-toggle'); await page.waitForTimeout(500);
+    const l4 = await label();
+    if (l4 === '一時停止') { ok('play-toggle: resumed'); } else { ng('play-toggle resume', `expected 一時停止 got ${l4}`); }
+
+    await page.click('#play-toggle'); await page.waitForTimeout(200);
+    const l5 = await label();
+    if (l5 === '再生') { ok('play-toggle: paused again'); } else { ng('play-toggle pause again', `expected 再生 got ${l5}`); }
+  } catch (e) { ng('Play/pause cycle', e.message); }
+
+  // ── 3. Play → pause → play (no black screen) ──
+  console.log('\n=== Black screen check ===');
+  try {
+    await ensurePaused();
+    await page.click('#play-toggle'); await page.waitForTimeout(800);
+    await page.click('#play-toggle'); await page.waitForTimeout(200);
+    await page.click('#play-toggle'); await page.waitForTimeout(800);
+    // Video should have a readyState >= 2 (HAVE_CURRENT_DATA) and not be paused
+    const vState = await page.evaluate(() => {
+      const v = document.getElementById('preview-video');
+      if (!v) return 'no-video';
+      return { paused: v.paused, readyState: v.readyState, currentTime: v.currentTime, src: v.src ? 'set' : 'empty' };
+    });
+    if (!vState.paused && vState.readyState >= 1) {
+      ok(`Video playing after resume (readyState=${vState.readyState}, t=${vState.currentTime.toFixed(2)})`);
+    } else {
+      ng('Video after resume', `paused=${vState.paused} readyState=${vState.readyState}`);
+    }
+    await page.click('#play-toggle'); await page.waitForTimeout(200);
+  } catch (e) { ng('Black screen check', e.message); }
+
+  // ── 4. Seek while paused → play ──
+  console.log('\n=== Seek + play ===');
+  try {
+    await ensurePaused();
+    // Seek to middle via slider
+    await page.evaluate(() => {
+      const el = document.getElementById('seek');
+      if (el && el.max && el.max > 0) {
+        el.value = el.max / 2;
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    });
+    await page.waitForTimeout(300);
+    const t1 = await page.evaluate(() => window.__test?.outputTime || 0);
+    await page.click('#play-toggle'); await page.waitForTimeout(500);
+    const t2 = await page.evaluate(() => window.__test?.outputTime || 0);
+    if (t2 > t1) {
+      ok(`Seek then play: time advanced ${t1.toFixed(2)} → ${t2.toFixed(2)}`);
+    } else {
+      ng('Seek then play', `time did not advance (${t1.toFixed(2)} → ${t2.toFixed(2)})`);
+    }
+    await page.click('#play-toggle'); await page.waitForTimeout(200);
+  } catch (e) { ng('Seek + play', e.message); }
+
+  // ── 5. Skip back / skip forward while paused ──
+  console.log('\n=== Skip buttons ===');
+  try {
+    await ensurePaused();
+    const t0 = await page.evaluate(() => window.__test?.outputTime || 0);
+    await page.click('#skip-forward'); await page.waitForTimeout(200);
+    const t1 = await page.evaluate(() => window.__test?.outputTime || 0);
+    if (t1 > t0) { ok(`skip-forward: ${t0.toFixed(2)} → ${t1.toFixed(2)}`); }
+    else { ng('skip-forward', `time did not advance (${t0.toFixed(2)} → ${t1.toFixed(2)})`); }
+
+    await page.click('#skip-back'); await page.waitForTimeout(200);
+    const t2 = await page.evaluate(() => window.__test?.outputTime || 0);
+    if (t2 < t1) { ok(`skip-back: ${t1.toFixed(2)} → ${t2.toFixed(2)}`); }
+    else { ng('skip-back', `time did not decrease (${t1.toFixed(2)} → ${t2.toFixed(2)})`); }
+  } catch (e) { ng('Skip buttons', e.message); }
+
+  // ── 6. Go to beginning (frame-back) ──
+  console.log('\n=== Go to beginning ===');
+  try {
+    await ensurePaused();
+    await page.evaluate(() => { const el = document.getElementById('seek'); if (el && el.max) el.value = el.max; el.dispatchEvent(new Event('input', { bubbles: true })); });
+    await page.waitForTimeout(200);
+    await page.click('#frame-back'); await page.waitForTimeout(300);
+    const t0 = await page.evaluate(() => window.__test?.outputTime ?? -1);
+    if (t0 >= 0 && t0 < 0.1) { ok(`frame-back: outputTime=${t0.toFixed(3)}`); }
+    else { ng('frame-back', `expected ~0 got ${t0.toFixed(3)}`); }
+  } catch (e) { ng('Go to beginning', e.message); }
+
+  // ── 7. Go to end (frame-forward) ──
+  console.log('\n=== Go to end ===');
+  try {
+    await ensurePaused();
+    await page.click('#frame-forward'); await page.waitForTimeout(300);
+    const tEnd = await page.evaluate(() => window.__test?.outputTime ?? -1);
+    const total = await page.evaluate(() => window.__test?.totalDuration ?? 0);
+    if (tEnd >= total - 0.05) { ok(`frame-forward to end: ${tEnd.toFixed(2)}/${total.toFixed(2)}`); }
+    else { ng('frame-forward', `expected ~${total.toFixed(2)} got ${tEnd.toFixed(2)}`); }
+  } catch (e) { ng('Go to end', e.message); }
+
+  // ── 8. Keyboard shortcuts ──
+  console.log('\n=== Keyboard shortcuts ===');
+  try {
+    // Home → beginning
+    await page.keyboard.press('Home'); await page.waitForTimeout(200);
+    const th = await page.evaluate(() => window.__test?.outputTime || -1);
+    if (th < 0.1) { ok('Home key → beginning'); } else { ng('Home key', `expected ~0 got ${th.toFixed(2)}`); }
+
+    // End → end
+    await page.keyboard.press('End'); await page.waitForTimeout(200);
+    const te = await page.evaluate(() => window.__test?.outputTime ?? -1);
+    const td = await page.evaluate(() => window.__test?.totalDuration ?? 0);
+    if (te >= td - 0.05) { ok('End key → end'); } else { ng('End key', `expected ~${td.toFixed(2)} got ${te.toFixed(2)}`); }
+
+    // Arrow step
+    await page.keyboard.press('Home'); await page.waitForTimeout(100);
+    const ta0 = await page.evaluate(() => window.__test?.outputTime ?? 0);
+    await page.keyboard.press('ArrowRight'); await page.waitForTimeout(100);
+    const ta1 = await page.evaluate(() => window.__test?.outputTime ?? 0);
+    if (ta1 > ta0) { ok(`ArrowRight: ${ta0.toFixed(3)} → ${ta1.toFixed(3)}`); }
+    else { ng('ArrowRight', `did not advance (${ta0.toFixed(3)} → ${ta1.toFixed(3)})`); }
+
+    await page.keyboard.press('ArrowLeft'); await page.waitForTimeout(100);
+    const ta2 = await page.evaluate(() => window.__test?.outputTime ?? 0);
+    if (ta2 < ta1) { ok(`ArrowLeft: ${ta1.toFixed(3)} → ${ta2.toFixed(3)}`); }
+    else { ng('ArrowLeft', `did not decrease (${ta1.toFixed(3)} → ${ta2.toFixed(3)})`); }
+  } catch (e) { ng('Keyboard shortcuts', e.message); }
+
+  // ── 9. Play then go to beginning while playing ──
+  console.log('\n=== Play + go to beginning while playing ===');
+  try {
+    await ensurePaused();
+    await page.keyboard.press('Home'); await page.waitForTimeout(100);
+    await page.click('#play-toggle'); await page.waitForTimeout(400);
+    const tp0 = await page.evaluate(() => window.__test?.outputTime ?? 0);
+    // Press Home WHILE playing (Home seeks to 0 without pausing)
+    await page.keyboard.press('Home'); await page.waitForTimeout(150);
+    const tp1 = await page.evaluate(() => window.__test?.outputTime ?? -1);
+    const stillPlaying = await page.evaluate(() => window.__test?.isPlaying);
+    if (tp1 >= 0 && tp1 < tp0 - 0.3 && stillPlaying) {
+      ok(`Play + Home while playing: ${tp0.toFixed(2)}→${tp1.toFixed(2)} playing=${stillPlaying}`);
+    } else {
+      ng('Play + Home while playing', `t=${tp0.toFixed(2)}→${tp1.toFixed(2)} playing=${stillPlaying}`);
+    }
+    await page.click('#play-toggle'); await page.waitForTimeout(200);
+  } catch (e) { ng('Play + go to beginning', e.message); }
+
+  // ── 10. Play → pause → go to beginning → play (BGM should reset) ──
+  console.log('\n=== Play → pause → beginning → play (BGM reset) ===');
+  try {
+    await ensurePaused();
+    // Play for a bit
+    await page.keyboard.press('Home'); await page.waitForTimeout(100);
+    await page.click('#play-toggle'); await page.waitForTimeout(1500);
+    await page.click('#play-toggle'); await page.waitForTimeout(200);
+    // Go to beginning
+    await page.click('#frame-back'); await page.waitForTimeout(300);
+    // Play again — should start from beginning
+    await page.click('#play-toggle'); await page.waitForTimeout(500);
+    const tb = await page.evaluate(() => window.__test?.outputTime ?? 0);
+    if (tb > 0 && tb < 1.5) {
+      ok(`Play after pause+beginning: time=${tb.toFixed(2)} (advanced from 0)`);
+    } else {
+      ng('Play after pause+beginning', `unexpected time ${tb.toFixed(2)}`);
+    }
+    await page.click('#play-toggle'); await page.waitForTimeout(200);
+  } catch (e) { ng('BGM reset', e.message); }
+
+  // ── 11. Fast play-then-pause cycle (rapid clicks) ──
+  console.log('\n=== Rapid play/pause ===');
+  try {
+    await ensurePaused();
+    await page.keyboard.press('Home'); await page.waitForTimeout(50);
+    for (let i = 0; i < 5; i++) {
+      await page.click('#play-toggle'); await page.waitForTimeout(100);
+    }
+    await page.waitForTimeout(200);
+    const finalLabel = await label();
+    ok(`Rapid 5x play/pause cycle OK (end state: ${finalLabel})`);
+  } catch (e) { ng('Rapid play/pause', e.message); }
+
+  // ── 12. Seek slider while playing ──
+  console.log('\n=== Seek while playing ===');
+  try {
+    await ensurePaused();
+    await page.keyboard.press('Home'); await page.waitForTimeout(100);
+    await page.click('#play-toggle'); await page.waitForTimeout(500);
+    const wasPlaying = await page.evaluate(() => window.__test?.isPlaying);
+    const tBefore = await page.evaluate(() => window.__test?.outputTime ?? -1);
+    // Seek via evaluate (dispatch input event)
+    await page.evaluate(() => {
+      const el = document.getElementById('seek');
+      if (el && el.max && el.max > 0) {
+        el.value = el.max * 0.75;
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    });
+    await page.waitForTimeout(400);
+    const tAfter = await page.evaluate(() => window.__test?.outputTime ?? -1);
+    const stillPlay = await page.evaluate(() => window.__test?.isPlaying);
+    if (stillPlay && Math.abs(tAfter - tBefore) > 0.5) {
+      ok(`Seek while playing: ${tBefore.toFixed(2)} → ${tAfter.toFixed(2)} (still playing)`);
+    } else {
+      ng('Seek while playing', `t=${tBefore.toFixed(2)}→${tAfter.toFixed(2)} playing=${stillPlay}`);
+    }
+    await page.click('#play-toggle'); await page.waitForTimeout(200);
+  } catch (e) { ng('Seek while playing', e.message); }
+
+  // ── 13. Final JS error check ──
+  console.log('\n=== JS errors ===');
+  const nonWsErrors = jsErrors.filter(e =>
+    !e.includes('ERR_CONNECTION_REFUSED') &&
+    !e.includes('WebSocket') &&
+    !e.includes('favicon') &&
+    !e.includes('play() request was interrupted') &&
+    !e.includes('The play() request')
+  );
+  if (nonWsErrors.length === 0) {
+    ok('No JS errors during controls test');
+  } else {
+    ng('JS errors', nonWsErrors.join('; '));
+  }
+
+  await page.close();
+  await browser.close();
+
+  printResults(passed, failed, results);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+function printResults(passed, failed, results) {
+  const total = passed + failed;
+  console.log(`\n${'═'.repeat(50)}`);
+  console.log(`Controls test: ${passed}/${total} passed, ${failed} failed\n`);
+  for (const r of results) console.log(r);
+  console.log(`\n${'═'.repeat(50)}`);
+}
+
+// ── Spawn server ──
+const srv = spawn('node', [
+  'src/server.mjs', PROJECT, '--port', String(PORT), '--no-lint',
+], {
+  cwd: path.resolve(import.meta.dirname, '..'),
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+srv.stdout.on('data', d => process.stdout.write(`[srv] ${d}`));
+srv.stderr.on('data', d => process.stderr.write(`[srv] ${d}`));
+
+try {
+  await waitForServer(`http://localhost:${PORT}/api/codec-info`);
+  await main();
+} finally {
+  srv.kill();
+  console.log('\n[cleanup] server stopped');
+}

--- a/packages/preview-server/test/controls.test.mjs
+++ b/packages/preview-server/test/controls.test.mjs
@@ -43,7 +43,8 @@ async function main() {
     ng('Page load', e.message);
     await browser.close();
     printResults(passed, failed, results);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   // Helper: check aria-label
@@ -298,7 +299,7 @@ async function main() {
   await browser.close();
 
   printResults(passed, failed, results);
-  process.exit(failed > 0 ? 1 : 0);
+  process.exitCode = failed > 0 ? 1 : 0;
 }
 
 function printResults(passed, failed, results) {

--- a/packages/preview-server/test/preview.test.mjs
+++ b/packages/preview-server/test/preview.test.mjs
@@ -410,7 +410,7 @@ async function main() {
   console.log(`結果: ${passed}/${total} passed, ${failed} failed\n`);
   for (const r of results) console.log(r);
   console.log(`\n${'═'.repeat(50)}`);
-  process.exit(failed > 0 ? 1 : 0);
+  process.exitCode = failed > 0 ? 1 : 0;
 }
 
 // ── Spawn server ──

--- a/packages/preview-server/test/preview.test.mjs
+++ b/packages/preview-server/test/preview.test.mjs
@@ -178,6 +178,166 @@ async function main() {
     try { await page.screenshot({ path: '/tmp/preview-test-error.png', fullPage: true }); } catch {}
   }
 
+  // ── Timeline editor tests ──
+  console.log('\n🖥️  Timeline editor tests');
+  try {
+    // Timeline canvas
+    await page.waitForSelector('#timeline-canvas', { timeout: 5000 });
+    ok('Timeline canvas found');
+
+    // Timeline controls
+    await page.waitForSelector('#tl-zoom-in');
+    await page.waitForSelector('#tl-zoom-out');
+    await page.waitForSelector('#tl-fit-btn');
+    ok('Timeline zoom controls found');
+
+    // Playhead exists
+    await page.waitForSelector('#tl-playhead');
+    ok('Timeline playhead found');
+
+    // Ruler exists
+    await page.waitForSelector('#tl-ruler-canvas');
+    ok('Timeline ruler found');
+
+    // Track headers (Video)
+    const headerCount = await page.locator('.timeline-track-header').count();
+    if (headerCount >= 2) {
+      ok(`Timeline track headers count=${headerCount}`);
+    } else {
+      ng('Track headers', `expected >=2 got ${headerCount}`);
+    }
+
+    // Canvas has segments drawn (width > 0)
+    const cw = await page.evaluate(() => {
+      const c = document.getElementById('timeline-canvas');
+      return c ? parseInt(c.style.width) : 0;
+    });
+    if (cw > 100) {
+      ok(`Timeline segments rendered (canvas width=${cw}px)`);
+    } else {
+      ng('Timeline segments', `canvas width=${cw}px`);
+    }
+
+    // Zoom fit button works
+    await page.click('#tl-fit-btn');
+    await page.waitForTimeout(200);
+    ok('Timeline fit clicked');
+
+    // Zoom in works
+    await page.click('#tl-zoom-in');
+    await page.waitForTimeout(200);
+    ok('Timeline zoom-in clicked');
+
+  } catch (e) {
+    ng('Timeline editor', e.message);
+    try { await page.screenshot({ path: '/tmp/timeline-test-error.png', fullPage: true }); } catch {}
+  }
+
+  // ── Asset browser tests ──
+  console.log('\n🖥️  Asset browser tests');
+  try {
+    await page.waitForSelector('#asset-list', { timeout: 5000 });
+    ok('Asset browser list found');
+
+    await page.waitForSelector('#asset-search');
+    ok('Asset search found');
+
+    await page.waitForSelector('#asset-tabs');
+    ok('Asset tabs found');
+
+    // Search input works
+    await page.fill('#asset-search', 'mp4');
+    await page.waitForTimeout(300);
+    ok('Asset search input filled');
+
+    // Clear search
+    await page.fill('#asset-search', '');
+    await page.waitForTimeout(200);
+
+    // Tab switching works
+    const tabs = page.locator('.asset-tab');
+    const tabCount = await tabs.count();
+    if (tabCount === 4) {
+      ok(`Asset tabs count=${tabCount}`);
+      // Click video tab
+      await tabs.nth(1).click();
+      await page.waitForTimeout(200);
+      // Check it became active
+      const active = await tabs.nth(1).getAttribute('class');
+      if (active?.includes('active')) {
+        ok('Asset tab switching works');
+      }
+      // Back to all
+      await tabs.nth(0).click();
+      await page.waitForTimeout(200);
+    } else {
+      ng('Asset tabs', `expected 4 got ${tabCount}`);
+    }
+  } catch (e) {
+    ng('Asset browser', e.message);
+    try { await page.screenshot({ path: '/tmp/asset-test-error.png', fullPage: true }); } catch {}
+  }
+
+  // ── Split / Delete cut tests ──
+  console.log('\n🖥️  Cut edit tests');
+  const editJsonPath = path.join(PROJECT, 'edit.json');
+  const editBackup = fs.readFileSync(editJsonPath, 'utf-8');
+  try {
+    // Wait for cuts to be rendered
+    await page.waitForTimeout(500);
+
+    // Get initial cut count
+    const initialCuts = await page.evaluate(() => window.__test?.summary?.cuts?.length || 0);
+    if (initialCuts < 1) {
+      ng('Split cut', `no cuts to split (count=${initialCuts})`);
+    } else {
+      ok(`Initial cuts: ${initialCuts}`);
+
+      // Seek to middle of first cut to split
+      await page.evaluate(() => {
+        const seg = window.__test.segments?.[0];
+        if (seg) window.__test.seekTo(seg.durationSec / 2);
+      });
+      await page.waitForTimeout(200);
+
+      // Press S to split
+      await page.keyboard.press('s');
+      await page.waitForTimeout(500);
+
+      // Get cut count after split
+      const afterSplit = await page.evaluate(() => window.__test?.summary?.cuts?.length || 0);
+      if (afterSplit === initialCuts + 1) {
+        ok(`Split: cuts ${initialCuts} → ${afterSplit}`);
+      } else {
+        ng('Split', `expected ${initialCuts + 1} cuts, got ${afterSplit}`);
+      }
+
+      // Delete the second cut (the new split)
+      await page.evaluate(() => {
+        const seg = window.__test?.getActiveSegment?.(window.__test.outputTime);
+        if (seg && seg.index >= 0) {
+          window.__test.seekTo(Math.max(0, seg.durationSec - 0.1));
+        }
+      });
+      await page.waitForTimeout(200);
+      await page.keyboard.press('Delete');
+      await page.waitForTimeout(500);
+
+      const afterDel = await page.evaluate(() => window.__test?.summary?.cuts?.length || 0);
+      // After split (N+1) then delete one = N
+      if (afterDel === initialCuts + 1 - 1) {
+        ok(`Delete: cuts ${initialCuts + 1} → ${afterDel}`);
+      } else {
+        ng('Delete', `expected ${initialCuts} cuts, got ${afterDel}`);
+      }
+
+    }
+    ok('Split+Delete tests passed');
+  } catch (e) {
+    ng('Cut edit', e.message);
+    try { await page.screenshot({ path: '/tmp/cut-edit-error.png', fullPage: true }); } catch {}
+  }
+
   // ── Output preview page ──
   console.log('\n🖥️  Output preview page');
   try {
@@ -240,6 +400,8 @@ async function main() {
   }
 
   await page.close();
+  // Restore edit.json (file watcher may trigger reload on server, safe after page close)
+  try { fs.writeFileSync(editJsonPath, editBackup, 'utf-8'); } catch {}
   await browser.close();
   if (!hadOutput) fs.unlinkSync(OUT_JSON);
 


### PR DESCRIPTION
## 概要
プレビューサーバー (`packages/preview-server`) を 3 ペインエディタへ改良し、タイムライン編集操作・素材ブラウザ・Viewer モードを追加。レビュー指摘対応とテスト整備を含みます。

## 変更内容
| コミット | 内容 |
|---|---|
| `98d0d1f` | [機能追加] 3 ペインエディタ化（素材ブラウザ・タイムライン・プレビュー/出力） |
| `5bc9da1` | [機能追加] タイムライン編集操作: 分割(S)・削除(Del)・スナッピング・カット情報ツールチップ |
| `d01a35b` | [test] Playwright: タイムラインエディタ・素材ブラウザ・分割/削除のテスト |
| `ffa60ed` | [修正] PR14 レビュー指摘 3 件対応 + プレビューエディタ機能追加（重複コミット・生成物・private データを履歴から除去） |
| `0d892f0` | [機能追加] Viewer モード: `--viewer` フラグで編集ロック切替（既定は editor モード） |
| `f4bdc14` | [test] テスト整備: 自己完結化（edit.json 復元・edit.output.json 自己生成・サーバーリーク解消）+ 新 UI 整合 |

## 検証
- `node --test`（`node --test packages/preview-server/test/`）: preview 41/41 / controls 25/25 / all-features 62/62 全 PASS
- `server.spec.mjs` は Playwright ランナー専用（`test.beforeAll` 使用）のため `node --test` 対象外。`npx playwright test` は上流 `f4ac5a2` の表示変更（`http://127.0.0.1:` 出力）と spec 側の `http://localhost:` 待ちの不整合により startup-timeout（既存の上流問題・スコープ外）
- 変更ファイルは `packages/preview-server/` 配下のみ

## その他
- コミットは 1PR=1課題、小さな PR 分割方針に沿って整理済み
- 秘密情報・API キーの混入なし
- issue は立てず直接 PR とします
