### PR TITLE
[機能追加] export-nle（BETA・実 NLE 取り込み未確認）— edit.json → FCPXML / FCP7 XML / SRT

### DIFF
--- a/.agents/skills/export-nle
+++ b/.agents/skills/export-nle
@@ -1,0 +1,1 @@
+../../skills/export-nle

--- a/.claude/skills/export-nle
+++ b/.claude/skills/export-nle
@@ -1,0 +1,1 @@
+../../skills/export-nle

--- a/.codex/skills/export-nle
+++ b/.codex/skills/export-nle
@@ -1,0 +1,1 @@
+../../skills/export-nle

--- a/.cursor/skills/export-nle
+++ b/.cursor/skills/export-nle
@@ -1,0 +1,1 @@
+../../skills/export-nle

--- a/.opencode/skills/export-nle
+++ b/.opencode/skills/export-nle
@@ -1,0 +1,1 @@
+../../skills/export-nle

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 
 <!-- BEGIN GENERATED skills-index — scripts/gen-skills-index.mjs が生成。手で編集しない -->
 
-スキル数: 17
+スキル数: 18
 
 | スキル | 発動条件（description） | 正本 |
 |---|---|---|
@@ -30,6 +30,7 @@
 | `create-project` | AKARI Video の新規プロジェクトを headless で作成する。`templates/project-default/` を再帰コピーし、雛形バージョンを記録し、安全な場合のみ git 初期化して、作成結果レポート HTML を生成する。アプリ起動は不要。新しい動画プロジェクトを作るとき、または既存フォルダを AKARI Video プロジェクトとして補完するときに使う。 | `skills/create-project/SKILL.md` |
 | `edit-lint` | edit.json と任意の analysis.json / captions.json / メディアを決定的 CLI で検査し、PASS 後のフレーム視認とレポートまで QA を完了する。edit.json を書いた、または変更した直後、書き出し前、レビュー指摘を反映した後の再確認で使う。 | `skills/edit-lint/SKILL.md` |
 | `edit-plan` | analyze-project が作る分析レポート（interpretation.json + analysis-report.html）を一次証拠として読み、方針・素材計画・実行をチャットの明示承認で確定したうえで edit.json v0 とオーバーレイ HTML へ落とすスキル。複数素材の編集計画、素材ゼロからの生成計画（質問対話 → plan.json の仮枠タイムライン確定）、分析結果からカットや BGM・SFX・B ロールを決める依頼で使う。 | `skills/edit-plan/SKILL.md` |
+| `export-nle` | BETA（実 NLE 取り込み未確認）: edit.json を Final Cut Pro / DaVinci Resolve（FCPXML）・Premiere Pro（FCP7 XML）・SRT 字幕へ書き出す。「Premiere で開きたい」「Final Cut に持っていきたい」「Resolve 用に書き出して」「SRT がほしい」で使う。移せないフィールドは dropped[] で必ず報告する。 | `skills/export-nle/SKILL.md` |
 | `generate-narration` | 原稿テキストから VOICEVOX（ローカル・ゼロ円の既製声）または fal Qwen3-TTS（自声クローン）でナレーション音声を生成し、edit.json の audio.narration[] へ書き込むスキル。ナレーションを作ってほしいと頼まれたとき、仮ナレ（下書き試聴）が欲しいとき、声プロファイルを新規に作りたいとき、または既存のナレーションをエンジンや声で差し替えたいときに使う。 | `skills/generate-narration/SKILL.md` |
 | `harvest-asset` | 案件で作った高コスト・再利用価値の高いオーバーレイ、3D、モーション、テロップ、サムネ構図、音源、B ロールを AKARI Video の assets ライブラリへ素材化するときに発動する。入庫判定、meta.json 下書き、preview、INDEX 更新、検証を行う。 | `skills/harvest-asset/SKILL.md` |
 | `manage-connections` | AKARI Video の生成プロバイダ・SNS 接続・API キー参照・モデル選択・コスト承認ポリシーを一元管理する。初回セットアップ、接続状態の確認、provider やモデルの追加、有償生成・外部公開の実行前ゲートで発動し、`.akari/connections.json` と無償・読み取り専用の doctor を扱う。 | `skills/manage-connections/SKILL.md` |

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-ff8a00)](./LICENSE)
 ![Status: under construction](https://img.shields.io/badge/status-under_construction-1a1a1a)
-![Agent skills: 17](https://img.shields.io/badge/agent_skills-17-ff8a00)
+![Agent skills: 18](https://img.shields.io/badge/agent_skills-18-ff8a00)
 ![opencode compatible](https://img.shields.io/badge/opencode-compatible-1a1a1a)
 ![Claude Code plugin](https://img.shields.io/badge/Claude_Code-plugin-1a1a1a)
 ![Cursor Agent](https://img.shields.io/badge/Cursor_Agent-skills-1a1a1a)
@@ -90,7 +90,7 @@ flowchart LR
 - **[Introduction](./docs/introduction.ja.md)** — 思想と全体像
 - **[Getting Started](./docs/getting-started.ja.md)** — 最初のプロジェクトを作る
 - **[Guides](./docs/README.ja.md#guides)** — 「素材を分析する」「編集計画を立てる」「書き出す」などタスク別ガイド
-- **[スキルカタログ](./docs/skills.ja.md)** — 17 スキルの一枚地図（各スキルの担当と接続先）
+- **[スキルカタログ](./docs/skills.ja.md)** — 18 スキルの一枚地図（各スキルの担当と接続先）
 - **[How-to](./docs/README.ja.md#how-to)** — 接続と API キー・プロジェクト構成・続きから再開
 - **[Reference](./docs/README.ja.md#reference)** — `edit.json` などファイル契約のスペック
 - 入口: [docs/README.ja.md](./docs/README.ja.md)
@@ -100,7 +100,7 @@ flowchart LR
 - `apps/shell/` — Theia ベースのデスクトップシェル
 - `packages/` — シェル非依存ライブラリ（schemas・プレビューエンジン・surface runtime・`akari-launcher`）
 - `templates/` — プロジェクト scaffold（`.opencode/` 設定を含む）
-- `skills/` — エージェント側ステージスキル（17 本）
+- `skills/` — エージェント側ステージスキル（18 本）
 - `plugin/` — Claude Code プラグインバンドル（スキルパック + SessionStart hook + `/akari`）
 - `catalog/` — キュレーション済みアドオンカタログ（参照配布のみ）
 - `docs/` — ユーザードキュメント + スペック契約

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-ff8a00)](./LICENSE)
 ![Status: under construction](https://img.shields.io/badge/status-under_construction-1a1a1a)
-![Agent skills: 17](https://img.shields.io/badge/agent_skills-17-ff8a00)
+![Agent skills: 18](https://img.shields.io/badge/agent_skills-18-ff8a00)
 ![opencode compatible](https://img.shields.io/badge/opencode-compatible-1a1a1a)
 ![Claude Code plugin](https://img.shields.io/badge/Claude_Code-plugin-1a1a1a)
 ![Cursor Agent](https://img.shields.io/badge/Cursor_Agent-skills-1a1a1a)
@@ -95,7 +95,7 @@ First steps: [docs/getting-started.md](./docs/getting-started.md).
 - **[Introduction](./docs/introduction.md)** — philosophy and the big picture
 - **[Getting Started](./docs/getting-started.md)** — create your first project
 - **[Guides](./docs/README.md#guides)** — task-based guides: analyze footage, plan the edit, export, …
-- **[Skills Catalog](./docs/skills.md)** — the 17-skill map: what each owns and what it connects to
+- **[Skills Catalog](./docs/skills.md)** — the 18-skill map: what each owns and what it connects to
 - **[How-to](./docs/README.md#how-to)** — connections & API keys, project structure, resuming a session
 - **[Reference](./docs/README.md#reference)** — specs for file contracts such as `edit.json`
 - Entry point: [docs/README.md](./docs/README.md)
@@ -109,7 +109,7 @@ First steps: [docs/getting-started.md](./docs/getting-started.md).
 - `apps/shell/` — Theia-based desktop shell
 - `packages/` — shell-independent libraries (schemas, preview engine, surface runtime, `akari-launcher`)
 - `templates/` — project scaffolds (include `.opencode/` config)
-- `skills/` — agent-side stage skills (17 of them)
+- `skills/` — agent-side stage skills (18 of them)
 - `plugin/` — Claude Code plugin bundle (skill pack + SessionStart hook + `/akari`)
 - `catalog/` — curated add-on catalog (reference-only distribution)
 - `docs/` — user docs + spec contracts

--- a/docs/contract-2026-08-01-export-nle-beta.md
+++ b/docs/contract-2026-08-01-export-nle-beta.md
@@ -1,0 +1,95 @@
+# 契約 — export-nle: 他社 NLE への書き出し（BETA・実 NLE 取り込み未確認）
+
+- 実装: `packages/export-nle/`（CLI: `bin/export-nle.mjs`）/ 入口スキル: `skills/export-nle/`
+- 地位: **beta-unverified** — 実装とユニットテスト（構造・時間量子化・写像）は済み。
+  **実 Final Cut Pro / DaVinci Resolve / Premiere Pro への取り込み検証は未実施**
+- 方向: **片道書き出しのみ**。NLE → edit.json の逆輸入は本契約のスコープ外（別契約になるまで着手しない）
+
+## 1. ターゲット形式
+
+| 出力 | 形式 | 想定インポータ |
+|---|---|---|
+| `<project>.fcpxml` | FCPXML 1.11 | Final Cut Pro / DaVinci Resolve |
+| `<project>.premiere.xml` | FCP7 XML（xmeml v5） | Premiere Pro |
+| `<project>.srt` | SRT | 全 NLE（captions.json 存在時のみ） |
+| `export-report.json` | レポート | `written[]` / `dropped[]` / `warnings[]` |
+
+`.prproj`（非公開形式）と CapCut draft（非公式・暗号化進行中）は狙わない。CapCut は需要が
+確認できた時点で lab スパイクとして別途判断する。
+
+## 2. 時間の量子化（丸めポリシー）
+
+- edit.json の秒 float は**必ず出力先のフレーム境界へ最近傍丸め**してから書く
+- FCPXML: `output.fps` を frameDuration 有理数へ変換（NTSC 系 23.976/29.97/59.94 →
+  1001/24000・1001/30000・1001/60000。整数 fps → 1/fps。その他 → ms 精度の有理数）。
+  全時刻は「フレーム数 × frameDuration」の約分済み有理数秒で表記
+- xmeml: 整数フレーム。NTSC 系は timebase 30/24/60 + `ntsc TRUE` とし、フレーム番号は
+  真の fps（30000/1001 等）で丸める
+- SRT: ms 精度
+
+## 3. タイムライン意味論（render-cut との整合）
+
+- カット配置・speed・xfade 重複・(src, source 秒) アンカー写像の**意味論の正本は
+  `packages/render-cut/src/cut-timeline.mjs` / `captions.mjs`**。export-nle は同じ式を
+  最小移植している（依存回避のため。render-cut 側が変わったら export-nle も追随する）
+- `at` / `track` 指定のない編集: 逐次連結 + xfade 重複減算（`computeCutTimelineOffsets` 同等）
+- `at` / `track` 指定のある編集（gap-aware）: 絶対配置。**この場合 transition_out は
+  書き出さない**（境界が隣接に限らないため。dropped で明示）
+- captions / beats / emphasis_words の start/end/t は timeline 秒ではなく (src, source 秒)
+  アンカー。書き出し時に cuts を通して timeline へ写像し、どのカットにも含まれない
+  アンカーは dropped に落とす
+
+## 4. フィールド別マッピング
+
+### 移る
+
+| edit.json | FCPXML | xmeml | 備考 |
+|---|---|---|---|
+| cuts[].in/out/at/track | asset-clip offset/start/duration | clipitem start/end/in/out | |
+| cuts[].speed | timeMap 2 点（⚠推定） | timeremap 定速（⚠推定） | 等速のみ |
+| cuts[].transform | adjust-transform（⚠座標系未検証） | Basic Motion（⚠center 未検証） | |
+| cuts[].opacity | adjust-blend amount | Opacity filter | |
+| transition_out dissolve | 子要素なし transition（= 既定 cross dissolve） | Cross Dissolve transitionitem | §5 の近似 |
+| transition_out fade-black/white | cross dissolve **近似** + dropped | 同左 | dip to color は手動再設定 |
+| layers（baked/video） | lane 2+ の connected clip | 上位 video track | アルファ付き mov はただのクリップ |
+| layers[].blend | adjust-blend mode（⚠未検証） | **落ちる**（warning） | |
+| audio.narration | lane -1 / role dialogue | audio track | gain は adjust-volume / audiolevels |
+| audio.sfx | lane -2-（track）/ role effects | audio track（sfx track 単位） | in/out 対応 |
+| audio.bgm | 実尺までループ展開 + fade キーフレーム（⚠推定） | 同左 | 実尺不明時は全体尺 1 クリップ + warning |
+| beats / emphasis_words | クリップ上の marker（source 秒のまま） | シーケンスマーカー（timeline へ写像） | 意味層はマーカーへ退化 |
+| captions.json | —（SRT へ） | —（SRT へ） | display_text 優先・プレーンテキスト |
+
+### 移らない（dropped[] に全件列挙 — 黙って落とさない）
+
+audio.bgm.ducking / audio.master（loudnorm・denoise）/ output.look（LUT）/
+sources[].chroma_key・layers[].chroma_key / direction / 字幕スタイル（style・text_style・words）/
+カット範囲外の beats・emphasis_words アンカー
+
+## 5. 既知の近似（ベータの明示的トレードオフ）
+
+1. **xfade**: AKARI レンダは重複区間の全時間 xfade。書き出しは「前カットの可視尺を重複分
+   詰めて突き合わせ + 境界中央寄せの transition」。**カット点と後続の同期は保存**されるが、
+   境界内のフレーム内容は近似
+2. **speed の交換表現**（FCPXML timeMap / xmeml timeremap）は仕様書と輸出物観察に基づく
+   推定実装。取り込み検証が最優先の未確認点
+3. **音量フェードのキーフレーム表現**（FCPXML adjust-volume param / xmeml audiolevels）は
+   取り込み側で無視されても成立する（フェードが落ち、gain は残る）
+4. メディアは**絶対パスの file URL 参照**。プロジェクト移動後は NLE 側 relink が前提
+
+## 6. 実行契約
+
+- 決定的 CLI（LLM 判断・乱数・現在時刻を混ぜない）。外部 npm 依存ゼロ、ffprobe は
+  media-bin 解決の本体直叩きのみ（`--no-probe` で完全オフライン、音声はプレースホルダ尺 + warning）
+- 読み取り専用: edit.json / captions.json を書き換えない。書き込みは `--out`（既定
+  `<project>/exports/nle/`）のみ
+- exit 0 = 書き出し完了（warnings 可）/ exit 2 = 入力・環境エラー
+
+## 7. ベータ卒業の条件（このリストが空になったら BETA 表記を外す）
+
+- [ ] Final Cut Pro 実機で fcpxml 取り込み確認（カット位置・音声同期・マーカー）
+- [ ] DaVinci Resolve 実機で fcpxml 取り込み確認（同上）
+- [ ] Premiere Pro 実機で premiere.xml 取り込み確認（同上 + timeremap / Basic Motion）
+- [ ] speed・transform・フェードの取り込み結果を §5 の近似メモへ反映（必要なら実装修正）
+- [ ] 取り込みテストの再現手順を verify スキル系列（L 系）に載せるか判断
+
+検証結果は本ファイルへ**追記**で記録する（結論の書き換えではなく履歴として残す）。

--- a/docs/skills.ja.md
+++ b/docs/skills.ja.md
@@ -2,7 +2,7 @@
 
 # スキルカタログ
 
-AKARI Video のエージェント側ワークフローは **17 のスキル**に分割されている（工程ごとに 1 つ + 横断 2 つ）。このページはその一枚地図 — 各スキルが何を担当し、いつ発動し、どの外部ツール・ランタイムに接続するかをまとめる。
+AKARI Video のエージェント側ワークフローは **18 のスキル**に分割されている（工程ごとに 1 つ + 横断 2 つ）。このページはその一枚地図 — 各スキルが何を担当し、いつ発動し、どの外部ツール・ランタイムに接続するかをまとめる。
 
 正本は各 `skills/<name>/SKILL.md`。ここは索引であり、手順・ハードルールの詳細は各 SKILL.md と関連契約（[Reference](./README.ja.md#reference)）に従う。
 
@@ -52,6 +52,7 @@ AKARI Video のエージェント側ワークフローは **17 のスキル**に
 | スキル | 担当 | 外部ツール・接続 |
 |---|---|---|
 | [render-cut](../skills/render-cut/SKILL.md) | 承認済み edit.json から最終 MP4 の計画 → 明示承認 → ローカル書き出し → 検証 → キーフレーム視認 | ffmpeg / ffprobe |
+| [export-nle](../skills/export-nle/SKILL.md) | **BETA（実 NLE 取り込み未確認）**: edit.json → FCPXML（Final Cut / Resolve）・FCP7 XML（Premiere）・SRT の片道書き出し。移せないフィールドは dropped[] で明示 | 同梱の決定的 CLI（ffprobe は任意） |
 
 ### 横断
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,7 +2,7 @@
 
 # Skills Catalog
 
-The agent-side workflow of AKARI Video is split into **17 skills** (one per production stage, plus two cross-cutting ones). This page is the single map: what each skill owns, when it triggers, and which external tools and runtimes it connects to.
+The agent-side workflow of AKARI Video is split into **18 skills** (one per production stage, plus two cross-cutting ones). This page is the single map: what each skill owns, when it triggers, and which external tools and runtimes it connects to.
 
 The canonical source for each skill is its `skills/<name>/SKILL.md`. This page is an index; for procedures and hard rules, follow each SKILL.md and the related contracts ([Reference](./README.md#reference)).
 
@@ -52,6 +52,7 @@ The canonical source for each skill is its `skills/<name>/SKILL.md`. This page i
 | Skill | Owns | External tools / connections |
 |---|---|---|
 | [render-cut](../skills/render-cut/SKILL.md) | From approved edit.json: plan → explicit approval → local export → verification → keyframe inspection | ffmpeg / ffprobe |
+| [export-nle](../skills/export-nle/SKILL.md) | **BETA (untested against real NLEs)**: one-way export of edit.json to FCPXML (Final Cut / Resolve), FCP7 XML (Premiere) and SRT. Non-portable fields are reported in dropped[] | bundled deterministic CLI (ffprobe optional) |
 
 ### Cross-cutting
 

--- a/packages/export-nle/bin/export-nle.mjs
+++ b/packages/export-nle/bin/export-nle.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+// export-nle — edit.json を他社 NLE の交換形式へ書き出す決定的 CLI（BETA・実 NLE 取り込み未確認）。
+//
+//   node packages/export-nle/bin/export-nle.mjs <project-root|edit.json> [options]
+//
+//   --format <list>   all | fcpxml,xmeml,srt（カンマ区切り。既定 all）
+//   --out <dir>       出力先（既定 <project>/exports/nle/）
+//   --no-probe        ffprobe による実尺取得をしない（音声はプレースホルダ尺）
+//   --json            機械向けレポートを stdout へ
+//
+// exit code: 0 = 書き出し完了（warnings 有無に関わらず）/ 2 = 入力・実行環境エラー。
+// 移せないフィールドは黙って落とさず report の dropped[] に列挙する。
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { loadEditFile, normalizeEdit, baseTimelineDuration } from "../src/edit-model.mjs";
+import { frameDuration } from "../src/time.mjs";
+import { probeDurations, timelineDurationWithMedia } from "../src/media.mjs";
+import { buildFcpxml } from "../src/fcpxml.mjs";
+import { buildXmeml } from "../src/xmeml.mjs";
+import { buildSrt, loadCaptions } from "../src/srt.mjs";
+
+const BETA_NOTICE =
+  "BETA: 生成物の実 NLE（Final Cut Pro / DaVinci Resolve / Premiere Pro）取り込みは未確認。取り込み結果の報告を歓迎します";
+
+const FORMATS = new Set(["fcpxml", "xmeml", "srt"]);
+
+function parseArgs(argv) {
+  const args = { input: null, formats: [...FORMATS], out: null, probe: true, json: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--format") {
+      const value = argv[index += 1] ?? "";
+      args.formats = value === "all" ? [...FORMATS] : value.split(",").map((item) => item.trim());
+      for (const format of args.formats) {
+        if (!FORMATS.has(format)) throw new Error(`未知の --format: ${format}（fcpxml / xmeml / srt / all）`);
+      }
+    } else if (arg === "--out") {
+      args.out = argv[index += 1] ?? null;
+    } else if (arg === "--no-probe") {
+      args.probe = false;
+    } else if (arg === "--json") {
+      args.json = true;
+    } else if (arg.startsWith("-")) {
+      throw new Error(`未知のオプション: ${arg}`);
+    } else if (args.input === null) {
+      args.input = arg;
+    } else {
+      throw new Error(`入力は 1 つだけ: ${arg}`);
+    }
+  }
+  if (!args.input) throw new Error("入力（project-root または edit.json）を指定してください");
+  return args;
+}
+
+async function resolveFfprobeOrNull(enabled, warnings) {
+  if (!enabled) return null;
+  // workspace インストール済みなら指定子で、未インストールでもモノレポ内なら相対で解決する
+  const candidates = [
+    "@akari-video/media-bin",
+    new URL("../../media-bin/src/index.mjs", import.meta.url).href,
+  ];
+  for (const specifier of candidates) {
+    try {
+      const { resolveFfprobe } = await import(specifier);
+      return resolveFfprobe();
+    } catch {
+      // 次の解決手段へ
+    }
+  }
+  warnings.push("ffprobe を解決できない（media-bin 不在）— 実尺取得なしで続行");
+  return null;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const { edit, editPath, projectRoot } = loadEditFile(args.input);
+  const model = normalizeEdit(edit, projectRoot);
+  const globalWarnings = [];
+  const ffprobePath = await resolveFfprobeOrNull(args.probe, globalWarnings);
+  const durations = probeDurations(model, {
+    ffprobePath,
+    onWarning: (message) => globalWarnings.push(message),
+  });
+  const fd = frameDuration(model.output.fps);
+  const totalDuration = timelineDurationWithMedia(model, baseTimelineDuration(model), durations);
+  if (totalDuration <= 0) throw new Error("タイムラインの尺が 0 — cuts / layers が空のプロジェクトは書き出せない");
+
+  const outDir = resolve(args.out ?? resolve(projectRoot, "exports", "nle"));
+  mkdirSync(outDir, { recursive: true });
+  const context = { durations, frameDur: fd, totalDuration };
+  const written = [];
+  const dropped = [];
+  const warnings = [...globalWarnings];
+
+  if (args.formats.includes("fcpxml")) {
+    const result = buildFcpxml(model, context);
+    const path = resolve(outDir, `${model.projectName}.fcpxml`);
+    writeFileSync(path, result.xml);
+    written.push({ format: "fcpxml", path, target: "Final Cut Pro / DaVinci Resolve" });
+    dropped.push(...result.dropped.map((entry) => ({ format: "fcpxml", ...entry })));
+    warnings.push(...result.warnings.filter((warning) => !warnings.includes(warning)));
+  }
+  if (args.formats.includes("xmeml")) {
+    const result = buildXmeml(model, context);
+    const path = resolve(outDir, `${model.projectName}.premiere.xml`);
+    writeFileSync(path, result.xml);
+    written.push({ format: "xmeml", path, target: "Premiere Pro（FCP7 XML 経由）" });
+    dropped.push(...result.dropped.map((entry) => ({ format: "xmeml", ...entry })));
+    warnings.push(...result.warnings.filter((warning) => !warnings.includes(warning)));
+  }
+  if (args.formats.includes("srt")) {
+    const captions = loadCaptions(projectRoot);
+    if (captions === null) {
+      warnings.push("captions.json が無いため SRT はスキップ");
+    } else {
+      const result = buildSrt(model, captions);
+      const path = resolve(outDir, `${model.projectName}.srt`);
+      writeFileSync(path, result.srt);
+      written.push({ format: "srt", path, cues: result.cueCount, target: "全 NLE 共通の字幕サイドカー" });
+      dropped.push(...result.dropped.map((entry) => ({ format: "srt", ...entry })));
+      warnings.push(...result.warnings.filter((warning) => !warnings.includes(warning)));
+    }
+  }
+
+  const report = {
+    tool: "export-nle",
+    status: "beta-unverified",
+    notice: BETA_NOTICE,
+    edit: editPath,
+    output: { width: model.output.width, height: model.output.height, fps: model.output.fps },
+    timeline_seconds: totalDuration,
+    probed: ffprobePath !== null,
+    written,
+    dropped,
+    warnings,
+  };
+  writeFileSync(resolve(outDir, "export-report.json"), `${JSON.stringify(report, null, 2)}\n`);
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(`⚠ ${BETA_NOTICE}\n`);
+    for (const file of written) {
+      process.stdout.write(`書き出し: ${file.path}（${file.target}）\n`);
+    }
+    if (dropped.length > 0) {
+      process.stdout.write(`移らないフィールド ${dropped.length} 件（詳細: export-report.json の dropped[]）:\n`);
+      for (const entry of dropped) {
+        process.stdout.write(`  - [${entry.format}] ${entry.field}: ${entry.reason}\n`);
+      }
+    }
+    for (const warning of warnings) {
+      process.stdout.write(`warning: ${warning}\n`);
+    }
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`export-nle: ${error.message}\n`);
+  process.exit(2);
+});

--- a/packages/export-nle/package.json
+++ b/packages/export-nle/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@akari-video/export-nle",
+  "version": "0.0.0",
+  "private": true,
+  "description": "edit.json を他社 NLE の交換形式（FCPXML / FCP7 XML / SRT)へ書き出す決定的 CLI。BETA — 実 NLE での取り込み動作は未確認。",
+  "type": "module",
+  "bin": {
+    "export-nle": "bin/export-nle.mjs"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "dependencies": {
+    "@akari-video/media-bin": "0.1.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/export-nle/src/dropped.mjs
+++ b/packages/export-nle/src/dropped.mjs
@@ -1,0 +1,55 @@
+// 交換形式に移せないフィールドの棚卸し。黙って落とさない（no silent caps）。
+// entry: { field, reason, hint } — report と CLI 出力の両方で使う。
+
+export function collectBaseDropped(model) {
+  const dropped = [];
+  const push = (field, reason, hint) => dropped.push({ field, reason, hint });
+
+  if (model.bgm?.ducking) {
+    push(
+      "audio.bgm.ducking",
+      "サイドチェーンダッキングはレンダ時処理で交換形式に対応概念がない",
+      "書き出し先で BGM トラックへ手動でダッキング（Premiere: Essential Sound / Resolve: Fairlight）を設定する",
+    );
+  }
+  if (model.master) {
+    push(
+      "audio.master",
+      "loudnorm / denoise はレンダ時処理で交換形式に移らない",
+      "書き出し先のラウドネス正規化（-14 LUFS 目安）を使う",
+    );
+  }
+  if (model.output?.look?.lut) {
+    push(
+      "output.look",
+      "LUT 適用は交換形式で相互運用できる表現がない",
+      `presets/luts の .cube を書き出し先で手動適用する（lut: ${model.output.look.lut}）`,
+    );
+  }
+  for (const source of model.sources) {
+    if (source.chroma_key) {
+      push(
+        `sources[${source.id}].chroma_key`,
+        "クロマキーのパラメータ（similarity/blend）は ffmpeg 語彙で NLE と互換がない",
+        "書き出し先のキーヤーを手動設定するか、アルファ付きに焼いてから読み込む",
+      );
+    }
+  }
+  for (const layer of model.layers) {
+    if (layer.chroma_key) {
+      push(
+        `layers[${layer.id}].chroma_key`,
+        "レイヤーのクロマキーは交換形式に移らない",
+        "書き出し先のキーヤーを手動設定する",
+      );
+    }
+  }
+  if (model.direction) {
+    push(
+      "direction",
+      "演出宣言（preset/intensity）は AKARI 固有の意味論で交換形式に対応概念がない",
+      "レンダ済み出力を参照するか、書き出し先で演出を再現する",
+    );
+  }
+  return dropped;
+}

--- a/packages/export-nle/src/edit-model.mjs
+++ b/packages/export-nle/src/edit-model.mjs
@@ -1,0 +1,180 @@
+// edit.json v0/v1 を読み込み、書き出し器が使う正規化モデルへ落とす。
+// タイムライン意味論（speed / at / xfade 重複 / 字幕の source 秒アンカー）の正本は
+// packages/render-cut/src/cut-timeline.mjs と captions.mjs。本ファイルはその最小移植で、
+// render-cut 側が変わったらここも追随する（依存を持たないのは、render-cut が
+// hyperframes / puppeteer-core を引き込むため。ドリフト検知は契約文書の責務）。
+
+import { readFileSync, statSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+
+export function cutSpeed(cut) {
+  const value = cut?.speed;
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 1;
+}
+
+export function segmentDuration(cut) {
+  return (cut.out - cut.in) / cutSpeed(cut);
+}
+
+const EPSILON = 1e-6;
+
+// render-cut/src/cut-timeline.mjs resolveCutSegments と同意味論:
+// track ごとのカーソルへ追記し、有効な at があれば上書きする。
+export function resolveCutSegments(cuts) {
+  const cursorByTrack = new Map();
+  const segments = [];
+  cuts.forEach((cut, index) => {
+    const hasValidTrack = Number.isInteger(cut.track) && cut.track >= 0;
+    const track = hasValidTrack ? cut.track : 0;
+    const duration = segmentDuration(cut);
+    const cursor = cursorByTrack.get(track) ?? 0;
+    const hasValidAt = typeof cut.at === "number" && Number.isFinite(cut.at) && cut.at >= 0;
+    const start = hasValidAt ? cut.at : cursor;
+    const end = start + duration;
+    cursorByTrack.set(track, end);
+    segments.push({ index, cut, track, start, end });
+  });
+  return segments;
+}
+
+export function needsGapAwareCutTimeline(cuts) {
+  if (!Array.isArray(cuts) || cuts.length === 0) return false;
+  const segments = resolveCutSegments(cuts);
+  let cursor = 0;
+  for (const segment of segments) {
+    if (segment.track !== 0) return true;
+    if (Math.abs(segment.start - cursor) > EPSILON) return true;
+    cursor = segment.end;
+  }
+  return false;
+}
+
+// render-cut/src/cut-timeline.mjs computeCutTimelineOffsets と同意味論:
+// 逐次連結で、xfade（transition_out）の重複時間だけ次カットの開始を前倒しする。
+export function computeCutTimelineOffsets(cuts) {
+  if (!Array.isArray(cuts) || cuts.length === 0) return [];
+  const offsets = [];
+  let start = 0;
+  let duration = segmentDuration(cuts[0]);
+  offsets.push({ start, duration });
+  for (let index = 1; index < cuts.length; index += 1) {
+    const boundary = cuts[index - 1].transition_out;
+    const transitionDuration = boundary ? boundary.duration : 0;
+    start = start + duration - transitionDuration;
+    duration = segmentDuration(cuts[index]);
+    offsets.push({ start, duration });
+  }
+  return offsets;
+}
+
+// render-cut/src/captions.mjs computeCaptionRanges の最小移植（linearTimeline=false 固定）。
+// captions / beats / emphasis_words の時刻は timeline 秒ではなく (src, source 秒) アンカー。
+export function sourceRangeToTimelineRanges(start, end, cuts, sourceId = null) {
+  if (!Array.isArray(cuts) || cuts.length === 0) {
+    return [{ start, duration: end - start, sourceStart: start, sourceEnd: end }];
+  }
+  const offsets = computeCutTimelineOffsets(cuts);
+  const ranges = [];
+  for (const [index, cut] of cuts.entries()) {
+    if (sourceId !== null && cut.src !== sourceId) continue;
+    const overlapStart = Math.max(start, cut.in);
+    const overlapEnd = Math.min(end, cut.out);
+    if (overlapEnd > overlapStart) {
+      const speed = cutSpeed(cut);
+      ranges.push({
+        start: offsets[index].start + (overlapStart - cut.in) / speed,
+        duration: (overlapEnd - overlapStart) / speed,
+        sourceStart: overlapStart,
+        sourceEnd: overlapEnd,
+      });
+    }
+  }
+  return ranges;
+}
+
+// source 秒の 1 点 t を timeline 秒へ写す。どのカットにも含まれなければ null。
+export function sourcePointToTimeline(t, cuts, sourceId = null) {
+  const ranges = sourceRangeToTimelineRanges(t, t + EPSILON, cuts, sourceId);
+  return ranges.length > 0 ? ranges[0].start : null;
+}
+
+export function loadEditFile(inputPath) {
+  const absolute = resolve(inputPath);
+  const stats = statSync(absolute);
+  const editPath = stats.isDirectory() ? resolve(absolute, "edit.json") : absolute;
+  const projectRoot = dirname(editPath);
+  const edit = JSON.parse(readFileSync(editPath, "utf8"));
+  return { edit, editPath, projectRoot };
+}
+
+export const V0_SOURCE_ID = "source";
+
+// v0/v1 の差（source 単数 / sources 配列 + cuts[].src）を吸収した正規化モデル。
+export function normalizeEdit(edit, projectRoot) {
+  const warnings = [];
+  const version = edit.version;
+  if (version !== 0 && version !== 1) {
+    throw new Error(`edit.json version が 0/1 ではない: ${JSON.stringify(version)}`);
+  }
+  const sources = version === 0
+    ? [{ id: V0_SOURCE_ID, path: edit.source.path, chroma_key: edit.source.chroma_key ?? null }]
+    : edit.sources.map((source) => ({
+        id: source.id,
+        path: source.path,
+        chroma_key: source.chroma_key ?? null,
+      }));
+  const cuts = (edit.cuts ?? []).map((cut) => (
+    version === 0 ? { ...cut, src: V0_SOURCE_ID } : { ...cut }
+  ));
+  for (const cut of cuts) {
+    if (!sources.some((source) => source.id === cut.src)) {
+      warnings.push(`cuts[].src "${cut.src}" が sources に見つからない — 参照整合は edit-lint の責務、書き出しは続行`);
+    }
+  }
+  const gapAware = needsGapAwareCutTimeline(cuts);
+  const placements = gapAware
+    ? resolveCutSegments(cuts).map(({ start, end }) => ({ start, duration: end - start }))
+    : computeCutTimelineOffsets(cuts);
+  const audio = edit.audio ?? {};
+  return {
+    version,
+    projectRoot,
+    projectName: basename(projectRoot),
+    output: edit.output,
+    sources,
+    cuts,
+    placements,
+    gapAware,
+    layers: edit.layers ?? [],
+    narration: audio.narration ?? [],
+    bgm: audio.bgm ?? null,
+    sfx: audio.sfx ?? [],
+    master: audio.master ?? null,
+    beats: edit.beats ?? [],
+    emphasisWords: edit.emphasis_words ?? [],
+    direction: edit.direction ?? null,
+    warnings,
+  };
+}
+
+// カット末尾・layers・sfx から合成尺を出す（render-cut/src/content-duration.mjs 相当の縮約。
+// narration / bgm は probe 結果があれば呼び出し側が拡張する）。
+export function baseTimelineDuration(model) {
+  let end = 0;
+  for (const placement of model.placements) {
+    end = Math.max(end, placement.start + placement.duration);
+  }
+  for (const layer of model.layers) {
+    if (typeof layer.t === "number" && typeof layer.duration === "number") {
+      end = Math.max(end, layer.t + layer.duration);
+    }
+  }
+  for (const item of model.sfx ?? []) {
+    if (typeof item.t !== "number") continue;
+    const inPoint = typeof item.in === "number" ? item.in : 0;
+    if (typeof item.out === "number" && item.out > inPoint) {
+      end = Math.max(end, item.t + (item.out - inPoint));
+    }
+  }
+  return end;
+}

--- a/packages/export-nle/src/fcpxml.mjs
+++ b/packages/export-nle/src/fcpxml.mjs
@@ -1,0 +1,406 @@
+// FCPXML 1.11 writer — Final Cut Pro / DaVinci Resolve 向け。
+//
+// 構造: spine 直下に全尺の gap を 1 つ置き、その connected 要素として
+//   lane 1  : カット列（nested spine — トランジションを置けるのは storyline だけ）
+//   lane 2+ : layers（アルファ付き mov / PinP 実映像）
+//   lane -1..: narration / sfx / bgm
+// gap は start=0 の等速なので、connected 要素の offset = timeline 秒がそのまま成立する。
+//
+// xfade は「前カットの可視尺を重複分だけ詰めて突き合わせ、境界を跨ぐ transition 要素を置く」
+// 近似で書く（AKARI レンダは全重複 xfade。カット点と後続の同期は保存、境界内のフレームは近似）。
+// ⚠ BETA: 実 FCP / Resolve への取り込みは未確認。特に timeMap（speed）・adjust-blend の
+// mode 名・adjust-volume のフェードキーフレームは仕様書ベースの推定実装。
+
+import { element, document as xmlDocument } from "./xml.mjs";
+import { fcpTime, fcpFrameDuration, toFrames } from "./time.mjs";
+import { collectBaseDropped } from "./dropped.mjs";
+import { collectMediaRefs, mediaFileUrl, isAudioOnlyPath } from "./media.mjs";
+import { cutSpeed } from "./edit-model.mjs";
+
+const PLACEHOLDER_AUDIO_SECONDS = 3;
+
+export function buildFcpxml(model, { durations, frameDur, totalDuration }) {
+  const warnings = [...model.warnings];
+  const dropped = collectBaseDropped(model);
+  const fd = frameDur;
+  const t = (seconds) => fcpTime(seconds, fd);
+  const halfFrame = fd.numerator / fd.denominator / 2;
+
+  // --- resources -------------------------------------------------------------
+  const formatId = "r1";
+  const assetIds = new Map();
+  const assetNodes = [];
+  const refs = collectMediaRefs(model);
+  refs.forEach((ref, index) => {
+    const id = `a${index + 1}`;
+    assetIds.set(ref.path, id);
+    const audioOnly = isAudioOnlyPath(ref.path);
+    const duration = durations.get(ref.path) ?? fallbackAssetDuration(model, ref, totalDuration);
+    assetNodes.push(
+      element(
+        "asset",
+        {
+          id,
+          name: ref.path.split("/").pop(),
+          start: "0s",
+          duration: t(duration),
+          hasVideo: audioOnly ? undefined : "1",
+          format: audioOnly ? undefined : formatId,
+          hasAudio: "1",
+          audioSources: "1",
+          audioChannels: "2",
+        },
+        [element("media-rep", { kind: "original-media", src: mediaFileUrl(model.projectRoot, ref.path) })],
+      ),
+    );
+  });
+
+  const resources = element("resources", {}, [
+    element("format", {
+      id: formatId,
+      name: `FFVideoFormat${model.output.height}p`,
+      frameDuration: fcpFrameDuration(fd),
+      width: String(Math.round(model.output.width)),
+      height: String(Math.round(model.output.height)),
+      colorSpace: "1-1-1 (Rec. 709)",
+    }),
+    ...assetNodes,
+  ]);
+
+  // --- カット列（lane 1）------------------------------------------------------
+  const gapChildren = [];
+  const looseMode = model.gapAware;
+  if (looseMode && model.cuts.some((cut) => cut.transition_out)) {
+    dropped.push({
+      field: "cuts[].transition_out",
+      reason: "at / track 指定のあるタイムラインではトランジション境界が隣接に限らないため書き出さない",
+      hint: "書き出し先で手動でトランジションを追加する",
+    });
+  }
+
+  const beatTargets = mapAnchorsToCuts(model, warnings, dropped);
+
+  if (model.cuts.length > 0 && !looseMode) {
+    const spineItems = [];
+    let cursor = 0;
+    model.cuts.forEach((cut, index) => {
+      const placement = model.placements[index];
+      const boundary = cut.transition_out && index + 1 < model.cuts.length
+        ? cut.transition_out
+        : null;
+      const visibleDuration = boundary
+        ? placement.duration - boundary.duration
+        : placement.duration;
+      if (placement.start - cursor > halfFrame) {
+        spineItems.push(element("gap", {
+          name: "Gap",
+          offset: t(cursor),
+          start: "0s",
+          duration: t(placement.start - cursor),
+        }));
+      }
+      spineItems.push(cutClipNode(model, cut, index, placement, visibleDuration, t, assetIds, beatTargets, fd));
+      cursor = placement.start + visibleDuration;
+      if (boundary) {
+        const junction = placement.start + visibleDuration;
+        spineItems.push(element("transition", {
+          name: transitionName(boundary.type),
+          offset: t(Math.max(placement.start, junction - boundary.duration / 2)),
+          duration: t(boundary.duration),
+        }));
+        if (boundary.type !== "dissolve") {
+          dropped.push({
+            field: `cuts[${index}].transition_out.type`,
+            reason: `${boundary.type} は FCPXML の既定トランジション（cross dissolve）で近似する`,
+            hint: "書き出し先で dip to color へ差し替える",
+          });
+        }
+      }
+    });
+    gapChildren.push(element("spine", { lane: "1", offset: "0s" }, spineItems));
+  } else if (model.cuts.length > 0) {
+    // gap-aware（at / track 指定あり）: 各カットを connected clip として絶対配置する
+    model.cuts.forEach((cut, index) => {
+      const placement = model.placements[index];
+      const lane = 1 + (Number.isInteger(cut.track) && cut.track >= 0 ? cut.track : 0);
+      gapChildren.push(cutClipNode(
+        model, cut, index, placement, placement.duration, t, assetIds, beatTargets, fd,
+        { lane: String(lane), offset: t(placement.start) },
+      ));
+    });
+  }
+
+  // --- layers（lane 2+）-------------------------------------------------------
+  const layerLaneBase = 1 + Math.max(1, ...model.cuts.map((cut) => 1 + (cut.track ?? 0)));
+  model.layers.forEach((layer, index) => {
+    const lane = layerLaneBase + (Number.isInteger(layer.track) && layer.track >= 0 ? layer.track : 0);
+    const children = [];
+    if (layer.transform) children.push(transformNode(layer.transform));
+    const blend = blendNode(layer.opacity, layer.blend, warnings);
+    if (blend) children.push(blend);
+    gapChildren.push(element("asset-clip", {
+      ref: assetIds.get(layer.src),
+      lane: String(lane),
+      offset: t(layer.t),
+      name: layer.id ?? `layer-${index + 1}`,
+      start: "0s",
+      duration: t(layer.duration),
+    }, children));
+  });
+
+  // --- audio（lane -1..）------------------------------------------------------
+  const sfxTracks = (model.sfx ?? []).map((item) => (Number.isInteger(item.track) && item.track >= 0 ? item.track : 0));
+  const maxSfxTrack = sfxTracks.length > 0 ? Math.max(...sfxTracks) : -1;
+  const bgmLane = -(3 + maxSfxTrack);
+
+  for (const item of model.narration) {
+    const duration = durations.get(item.path) ?? placeholderDuration(item.path, "narration", warnings);
+    gapChildren.push(audioClipNode(assetIds.get(item.path), {
+      lane: "-1",
+      offset: t(item.t),
+      name: item.id,
+      start: "0s",
+      duration: t(duration),
+      audioRole: "dialogue",
+    }, item.gain_db, t));
+  }
+  for (const item of model.sfx ?? []) {
+    const inPoint = typeof item.in === "number" ? item.in : 0;
+    const known = typeof item.out === "number"
+      ? item.out - inPoint
+      : (durations.get(item.path) ?? placeholderDuration(item.path, "sfx", warnings)) - inPoint;
+    const track = Number.isInteger(item.track) && item.track >= 0 ? item.track : 0;
+    gapChildren.push(audioClipNode(assetIds.get(item.path), {
+      lane: String(-2 - track),
+      offset: t(item.t),
+      name: item.path.split("/").pop(),
+      start: t(inPoint),
+      duration: t(Math.max(known, fd.numerator / fd.denominator)),
+      audioRole: "effects",
+    }, item.gain_db, t));
+  }
+  if (model.bgm) {
+    emitBgmClips(model, gapChildren, { durations, t, totalDuration, bgmLane, assetIds, warnings, fd });
+  }
+
+  // --- 全体 -------------------------------------------------------------------
+  const gap = element("gap", {
+    name: "AKARI Timeline",
+    offset: "0s",
+    start: "0s",
+    duration: t(totalDuration),
+  }, gapChildren);
+
+  const root = element("fcpxml", { version: "1.11" }, [
+    resources,
+    element("library", {}, [
+      element("event", { name: "AKARI Export" }, [
+        element("project", { name: model.projectName }, [
+          element("sequence", {
+            format: formatId,
+            duration: t(totalDuration),
+            tcStart: "0s",
+            tcFormat: "NDF",
+            audioLayout: "stereo",
+            audioRate: "48k",
+          }, [element("spine", {}, [gap])]),
+        ]),
+      ]),
+    ]),
+  ]);
+
+  return { xml: xmlDocument(root, "<!DOCTYPE fcpxml>"), dropped, warnings };
+}
+
+function cutClipNode(model, cut, index, placement, visibleDuration, t, assetIds, beatTargets, fd, extraAttrs = {}) {
+  const children = [];
+  const speed = cutSpeed(cut);
+  if (speed !== 1) {
+    // ⚠ 未検証: 等速リタイムを 2 点の timeMap で表現する（time=クリップ内時間 / value=素材時間）
+    children.push(element("timeMap", {}, [
+      element("timept", { time: t(cut.in), value: t(cut.in), interp: "smooth2" }),
+      element("timept", {
+        time: t(cut.in + visibleDuration),
+        value: t(cut.in + visibleDuration * speed),
+        interp: "smooth2",
+      }),
+    ]));
+  }
+  if (cut.transform) children.push(transformNode(cut.transform));
+  const blend = blendNode(cut.opacity, null, null);
+  if (blend) children.push(blend);
+  for (const marker of beatTargets.get(index) ?? []) {
+    children.push(element("marker", {
+      start: t(marker.start),
+      duration: t(Math.max(marker.duration, fd.numerator / fd.denominator)),
+      value: marker.value,
+      note: marker.note || undefined,
+    }));
+  }
+  return element("asset-clip", {
+    ref: assetIds.get(sourcePath(model, cut.src)),
+    offset: t(placement.start),
+    name: `${cut.src} ${index + 1}`,
+    start: t(cut.in),
+    duration: t(visibleDuration),
+    ...extraAttrs,
+  }, children);
+}
+
+// beats / emphasis_words は (src, source 秒) アンカー。カット内側の時刻はクリップの
+// ローカル時間 = 素材時間なので、含むカットのクリップへそのまま marker として付ける。
+function mapAnchorsToCuts(model, warnings, dropped) {
+  const targets = new Map();
+  const attach = (anchorStart, anchorEnd, src, value, note, field) => {
+    const index = model.cuts.findIndex((cut) =>
+      (src === null || cut.src === src) && anchorStart >= cut.in && anchorStart < cut.out);
+    if (index === -1) {
+      dropped.push({ field, reason: "アンカーがどのカットにも含まれない", hint: "カット範囲外のマーカーは書き出されない" });
+      return;
+    }
+    if (!targets.has(index)) targets.set(index, []);
+    targets.get(index).push({
+      start: anchorStart,
+      duration: Math.max(0, anchorEnd - anchorStart),
+      value,
+      note,
+    });
+  };
+  for (const beat of model.beats) {
+    const src = typeof beat.src === "string" ? beat.src : (model.version === 0 ? null : null);
+    attach(beat.t, beat.t, src, `beat:${beat.kind} (${beat.strength})`, beat.basis ?? "", `beats[${beat.id}]`);
+  }
+  for (const word of model.emphasisWords) {
+    const src = typeof word.src === "string" ? word.src : null;
+    const note = [word.emotion, word.style_hint].filter(Boolean).join(" / ");
+    attach(word.t_start, word.t_end, src, `emphasis:${word.word}`, note, `emphasis_words[${word.id}]`);
+  }
+  return targets;
+}
+
+function emitBgmClips(model, gapChildren, { durations, t, totalDuration, bgmLane, assetIds, warnings, fd }) {
+  const bgm = model.bgm;
+  const assetDuration = durations.get(bgm.path);
+  const inPoint = typeof bgm.in === "number" ? bgm.in : 0;
+  const fadeIn = typeof bgm.fadeIn === "number" ? bgm.fadeIn : 0;
+  const fadeOut = typeof bgm.fadeOut === "number" ? bgm.fadeOut : 0;
+  const pieces = [];
+  if (typeof assetDuration === "number" && assetDuration > 0) {
+    // タイムライン全体尺までループ展開（AKARI レンダのループ意味論の実体化）
+    let covered = 0;
+    let first = true;
+    while (covered < totalDuration - fd.numerator / fd.denominator / 2) {
+      const start = first ? Math.min(inPoint, assetDuration) : 0;
+      const available = assetDuration - start;
+      const duration = Math.min(available, totalDuration - covered);
+      if (duration <= 0) break;
+      pieces.push({ offset: covered, start, duration });
+      covered += duration;
+      first = false;
+    }
+  } else {
+    warnings.push(`bgm の実尺が不明（ffprobe 不使用/失敗）— ループ展開せず全体尺 1 クリップで書き出す: ${bgm.path}`);
+    pieces.push({ offset: 0, start: inPoint, duration: totalDuration });
+  }
+  pieces.forEach((piece, index) => {
+    const isFirst = index === 0;
+    const isLast = index === pieces.length - 1;
+    const gain = typeof bgm.gain_db === "number" ? bgm.gain_db : 0;
+    const children = [];
+    const fadeKeyframes = [];
+    if (isFirst && fadeIn > 0) {
+      fadeKeyframes.push({ time: 0, value: -96 }, { time: Math.min(fadeIn, piece.duration), value: gain });
+    }
+    if (isLast && fadeOut > 0) {
+      fadeKeyframes.push(
+        { time: Math.max(0, piece.duration - fadeOut), value: gain },
+        { time: piece.duration, value: -96 },
+      );
+    }
+    if (fadeKeyframes.length > 0) {
+      // ⚠ 未検証: フェードを adjust-volume の keyframeAnimation で表現する
+      children.push(element("adjust-volume", {}, [
+        element("param", { name: "amount" }, [
+          element("keyframeAnimation", {}, fadeKeyframes.map((keyframe) =>
+            element("keyframe", { time: t(keyframe.time), value: `${keyframe.value}dB` }))),
+        ]),
+      ]));
+    } else if (gain !== 0) {
+      children.push(element("adjust-volume", { amount: `${gain}dB` }));
+    }
+    gapChildren.push(element("asset-clip", {
+      ref: assetIds.get(bgm.path),
+      lane: String(bgmLane),
+      offset: t(piece.offset),
+      name: `bgm${pieces.length > 1 ? ` (loop ${index + 1})` : ""}`,
+      start: t(piece.start),
+      duration: t(piece.duration),
+      audioRole: "music",
+    }, children));
+  });
+}
+
+function audioClipNode(ref, attrs, gainDb, t) {
+  const children = [];
+  if (typeof gainDb === "number" && gainDb !== 0) {
+    children.push(element("adjust-volume", { amount: `${gainDb}dB` }));
+  }
+  return element("asset-clip", { ref, ...attrs }, children);
+}
+
+function transformNode(transform) {
+  const x = typeof transform.x === "number" ? transform.x : 0;
+  const y = typeof transform.y === "number" ? transform.y : 0;
+  const scale = typeof transform.scale === "number" ? transform.scale : 1;
+  const rotate = typeof transform.rotate === "number" ? transform.rotate : 0;
+  // ⚠ 未検証: position の単位は AKARI の px 値をそのまま書く（FCP 側の座標系差は取り込み時要確認）
+  return element("adjust-transform", {
+    position: `${x} ${y}`,
+    scale: `${scale} ${scale}`,
+    rotation: String(rotate),
+  });
+}
+
+function blendNode(opacity, blendMode, warnings) {
+  const hasOpacity = typeof opacity === "number" && opacity < 1;
+  const hasMode = typeof blendMode === "string" && blendMode !== "normal";
+  if (!hasOpacity && !hasMode) return null;
+  if (hasMode) {
+    warnings?.push(`blend mode "${blendMode}" は FCPXML の mode 名へそのまま書く（未検証・取り込み側で無視される可能性あり）`);
+  }
+  return element("adjust-blend", {
+    amount: hasOpacity ? String(opacity) : "1",
+    mode: hasMode ? blendMode : undefined,
+  });
+}
+
+function transitionName(type) {
+  // FCPXML は子要素なしの transition が既定の cross dissolve になる。
+  // fade-black / fade-white は名前だけ変えて cross dissolve 近似（dropped で明示）。
+  if (type === "fade-black") return "Fade To Black (approximated)";
+  if (type === "fade-white") return "Fade To White (approximated)";
+  return "Cross Dissolve";
+}
+
+function sourcePath(model, srcId) {
+  return model.sources.find((source) => source.id === srcId)?.path;
+}
+
+function fallbackAssetDuration(model, ref, totalDuration) {
+  if (ref.roles.has("source")) {
+    const sourceIds = model.sources.filter((s) => s.path === ref.path).map((s) => s.id);
+    const outs = model.cuts.filter((cut) => sourceIds.includes(cut.src)).map((cut) => cut.out);
+    if (outs.length > 0) return Math.max(...outs);
+  }
+  if (ref.roles.has("layer")) {
+    const durations = model.layers.filter((layer) => layer.src === ref.path).map((layer) => layer.duration);
+    if (durations.length > 0) return Math.max(...durations);
+  }
+  if (ref.roles.has("bgm")) return totalDuration;
+  return PLACEHOLDER_AUDIO_SECONDS;
+}
+
+function placeholderDuration(path, role, warnings) {
+  warnings.push(`${role} の実尺が不明（ffprobe 不使用/失敗）— ${PLACEHOLDER_AUDIO_SECONDS}s のプレースホルダ尺で書き出す: ${path}`);
+  return PLACEHOLDER_AUDIO_SECONDS;
+}

--- a/packages/export-nle/src/media.mjs
+++ b/packages/export-nle/src/media.mjs
@@ -1,0 +1,82 @@
+// 参照メディアの収集と ffprobe による実尺取得（任意）。
+// ffprobe の解決は media-bin（AKARI_FFPROBE_BIN → FFMPEG_PATH → PATH → static）へ委譲。
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const AUDIO_EXTENSIONS = new Set(["mp3", "wav", "aac", "m4a", "flac", "ogg", "aiff", "aif"]);
+
+export function absoluteMediaPath(projectRoot, mediaPath) {
+  return isAbsolute(mediaPath) ? mediaPath : resolve(projectRoot, mediaPath);
+}
+
+export function mediaFileUrl(projectRoot, mediaPath) {
+  return pathToFileURL(absoluteMediaPath(projectRoot, mediaPath)).href;
+}
+
+export function isAudioOnlyPath(mediaPath) {
+  const extension = mediaPath.split(".").pop()?.toLowerCase() ?? "";
+  return AUDIO_EXTENSIONS.has(extension);
+}
+
+// モデルが参照する全メディアパス（project 相対の生値）を役割付きで列挙する。
+export function collectMediaRefs(model) {
+  const refs = new Map();
+  const add = (path, role) => {
+    if (typeof path !== "string" || path.trim() === "") return;
+    if (!refs.has(path)) refs.set(path, { path, roles: new Set() });
+    refs.get(path).roles.add(role);
+  };
+  for (const source of model.sources) add(source.path, "source");
+  for (const layer of model.layers) add(layer.src, "layer");
+  for (const item of model.narration) add(item.path, "narration");
+  for (const item of model.sfx ?? []) add(item.path, "sfx");
+  if (model.bgm) add(model.bgm.path, "bgm");
+  return [...refs.values()];
+}
+
+export function probeDurations(model, { ffprobePath, onWarning }) {
+  const durations = new Map();
+  if (!ffprobePath) return durations;
+  for (const ref of collectMediaRefs(model)) {
+    const absolute = absoluteMediaPath(model.projectRoot, ref.path);
+    if (!existsSync(absolute)) {
+      onWarning?.(`メディアが見つからない: ${ref.path} — 実尺不明のまま書き出す`);
+      continue;
+    }
+    const result = spawnSync(
+      ffprobePath,
+      ["-v", "error", "-show_entries", "format=duration", "-of", "csv=p=0", absolute],
+      { encoding: "utf8" },
+    );
+    const parsed = Number.parseFloat(result.stdout?.trim());
+    if (result.status === 0 && Number.isFinite(parsed) && parsed > 0) {
+      durations.set(ref.path, parsed);
+    } else {
+      onWarning?.(`ffprobe が実尺を取得できない: ${ref.path}`);
+    }
+  }
+  return durations;
+}
+
+// probe 結果を含めた合成尺。narration は t + 実尺まで伸ばす（不明なら含めない）。
+export function timelineDurationWithMedia(model, baseDuration, durations) {
+  let end = baseDuration;
+  for (const item of model.narration) {
+    const duration = durations.get(item.path);
+    if (typeof item.t === "number" && typeof duration === "number") {
+      end = Math.max(end, item.t + duration);
+    }
+  }
+  for (const item of model.sfx ?? []) {
+    if (typeof item.t !== "number" || typeof item.out === "number") continue;
+    const duration = durations.get(item.path);
+    const inPoint = typeof item.in === "number" ? item.in : 0;
+    if (typeof duration === "number" && duration > inPoint) {
+      end = Math.max(end, item.t + (duration - inPoint));
+    }
+  }
+  return end;
+}

--- a/packages/export-nle/src/srt.mjs
+++ b/packages/export-nle/src/srt.mjs
@@ -1,0 +1,46 @@
+// captions.json → SRT サイドカー。全 NLE（FCP / Premiere / Resolve / CapCut）が読める
+// 最小公倍数の字幕交換。captions の start/end は (src, source 秒) アンカーなので、
+// render-cut と同じ写像（xfade 重複込みの逐次連結）で timeline 秒へ落としてから書く。
+// スタイル（text_style / style / emphasis）は SRT に表現がなく落ちる（dropped で明示）。
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { srtTime } from "./time.mjs";
+import { sourceRangeToTimelineRanges } from "./edit-model.mjs";
+
+export function loadCaptions(projectRoot) {
+  const path = resolve(projectRoot, "captions.json");
+  if (!existsSync(path)) return null;
+  const parsed = JSON.parse(readFileSync(path, "utf8"));
+  return Array.isArray(parsed) ? parsed : parsed.captions ?? [];
+}
+
+export function buildSrt(model, captions) {
+  const warnings = [...model.warnings];
+  const dropped = [];
+  if (captions.some((caption) => caption.style || caption.text_style || caption.words)) {
+    dropped.push({
+      field: "captions[].style / text_style / words",
+      reason: "SRT はプレーンテキストのみ。カラオケ演出・座布団・語タイミングは落ちる",
+      hint: "見た目込みが必要なら AKARI レンダ（焼き込み）を使う",
+    });
+  }
+  const cues = [];
+  for (const caption of captions) {
+    const source = typeof caption.src === "string" && caption.src !== "" ? caption.src : null;
+    if (source === null && model.sources.length > 1) {
+      warnings.push(`captions.json ${caption.id ?? "(unknown)"} はマルチソース編集で src がないためスキップ`);
+      continue;
+    }
+    const text = typeof caption.display_text === "string" ? caption.display_text : caption.text;
+    for (const range of sourceRangeToTimelineRanges(caption.start, caption.end, model.cuts, source)) {
+      if (range.duration <= 0) continue;
+      cues.push({ start: range.start, end: range.start + range.duration, text });
+    }
+  }
+  cues.sort((a, b) => a.start - b.start || a.end - b.end);
+  const body = cues
+    .map((cue, index) => `${index + 1}\n${srtTime(cue.start)} --> ${srtTime(cue.end)}\n${cue.text}`)
+    .join("\n\n");
+  return { srt: body.length > 0 ? `${body}\n` : "", cueCount: cues.length, dropped, warnings };
+}

--- a/packages/export-nle/src/time.mjs
+++ b/packages/export-nle/src/time.mjs
@@ -1,0 +1,84 @@
+// 時間表現の量子化と各形式への整形。
+// edit.json は秒 float、FCPXML は有理数秒（"1001/30000s"）、xmeml は整数フレーム。
+// すべての出力時刻はフレーム境界へ丸めてから整形する（丸めずに書くと FCPX が
+// 「not on an edit frame boundary」警告を出し、xmeml では 1 フレームずれが積もる）。
+
+const NTSC_FAMILIES = [
+  { fps: 24000 / 1001, numerator: 1001, denominator: 24000, timebase: 24 },
+  { fps: 30000 / 1001, numerator: 1001, denominator: 30000, timebase: 30 },
+  { fps: 60000 / 1001, numerator: 1001, denominator: 60000, timebase: 60 },
+];
+
+const FPS_EPSILON = 0.005;
+
+function gcd(a, b) {
+  let x = Math.abs(a);
+  let y = Math.abs(b);
+  while (y !== 0) [x, y] = [y, x % y];
+  return x || 1;
+}
+
+// fps → 1 フレームの尺（有理数秒）。NTSC 系（23.976 / 29.97 / 59.94）は 1001 系へ、
+// 整数 fps は 1/fps へ。それ以外は ms 精度で有理数化する。
+export function frameDuration(fps) {
+  for (const family of NTSC_FAMILIES) {
+    if (Math.abs(fps - family.fps) < FPS_EPSILON) {
+      return { numerator: family.numerator, denominator: family.denominator };
+    }
+  }
+  if (Number.isInteger(fps)) return { numerator: 1, denominator: fps };
+  const denominator = Math.round(fps * 1000);
+  const divisor = gcd(1000, denominator);
+  return { numerator: 1000 / divisor, denominator: denominator / divisor };
+}
+
+export function exactFps(fd) {
+  return fd.denominator / fd.numerator;
+}
+
+// 秒 → フレーム番号（最近傍丸め）。
+export function toFrames(seconds, fd) {
+  return Math.round((seconds * fd.denominator) / fd.numerator);
+}
+
+// 秒 → FCPXML の有理数秒文字列。フレーム境界へ量子化してから約分する。
+export function fcpTime(seconds, fd) {
+  const frames = toFrames(seconds, fd);
+  const numerator = frames * fd.numerator;
+  if (numerator === 0) return "0s";
+  const divisor = gcd(numerator, fd.denominator);
+  const n = numerator / divisor;
+  const d = fd.denominator / divisor;
+  return d === 1 ? `${n}s` : `${n}/${d}s`;
+}
+
+// FCPXML format 要素の frameDuration 属性値。
+export function fcpFrameDuration(fd) {
+  return fd.numerator === 1 && fd.denominator === 1
+    ? "1s"
+    : `${fd.numerator}/${fd.denominator}s`;
+}
+
+// xmeml の rate 要素（整数 timebase + ntsc フラグ）。
+export function xmemlRate(fps) {
+  for (const family of NTSC_FAMILIES) {
+    if (Math.abs(fps - family.fps) < FPS_EPSILON) {
+      return { timebase: family.timebase, ntsc: true };
+    }
+  }
+  return { timebase: Math.round(fps), ntsc: false };
+}
+
+// SRT のタイムスタンプ "HH:MM:SS,mmm"。
+export function srtTime(seconds) {
+  const clamped = Math.max(0, seconds);
+  const totalMs = Math.round(clamped * 1000);
+  const ms = totalMs % 1000;
+  const totalSeconds = (totalMs - ms) / 1000;
+  const s = totalSeconds % 60;
+  const totalMinutes = (totalSeconds - s) / 60;
+  const m = totalMinutes % 60;
+  const h = (totalMinutes - m) / 60;
+  const pad = (value, width = 2) => String(value).padStart(width, "0");
+  return `${pad(h)}:${pad(m)}:${pad(s)},${pad(ms, 3)}`;
+}

--- a/packages/export-nle/src/xmeml.mjs
+++ b/packages/export-nle/src/xmeml.mjs
@@ -1,0 +1,468 @@
+// FCP7 XML (xmeml v5) writer — Premiere Pro 向け。
+// 時刻は全て整数フレーム（timebase + ntsc フラグ）。NTSC 系 fps は timebase 30/24/60 +
+// ntsc TRUE に落とし、フレーム番号は真の fps で丸める。
+// ⚠ BETA: 実 Premiere への取り込みは未確認。特に timeremap（speed）・Basic Motion の
+// center 座標系・audiolevels のキーフレームは仕様書と既存輸出物の観察に基づく推定実装。
+
+import { element, document as xmlDocument } from "./xml.mjs";
+import { xmemlRate, exactFps } from "./time.mjs";
+import { collectBaseDropped } from "./dropped.mjs";
+import { collectMediaRefs, isAudioOnlyPath, absoluteMediaPath } from "./media.mjs";
+import { cutSpeed, sourcePointToTimeline } from "./edit-model.mjs";
+import { pathToFileURL } from "node:url";
+
+const PLACEHOLDER_AUDIO_SECONDS = 3;
+
+// float 演算のノイズ（1.2 * 100 = 120.00000000000001 等）を落として文字列化する。
+function num(value) {
+  return String(Math.round(value * 1e6) / 1e6);
+}
+
+export function buildXmeml(model, { durations, frameDur, totalDuration }) {
+  const warnings = [...model.warnings];
+  const dropped = collectBaseDropped(model);
+  const fps = exactFps(frameDur);
+  const rate = xmemlRate(fps);
+  const toFrame = (seconds) => Math.round(seconds * fps);
+  const rateNode = () => element("rate", {}, [
+    element("timebase", {}, [], String(rate.timebase)),
+    element("ntsc", {}, [], rate.ntsc ? "TRUE" : "FALSE"),
+  ]);
+
+  // --- file 定義（初出でフル定義、以後は id 参照のみ）---------------------------
+  const fileIds = new Map();
+  const fileDefined = new Set();
+  collectMediaRefs(model).forEach((ref, index) => fileIds.set(ref.path, `file-${index + 1}`));
+  const fileNode = (path) => {
+    const id = fileIds.get(path);
+    if (fileDefined.has(id)) return element("file", { id });
+    fileDefined.add(id);
+    const audioOnly = isAudioOnlyPath(path);
+    const known = durations.get(path);
+    const children = [
+      element("name", {}, [], path.split("/").pop()),
+      element("pathurl", {}, [], pathToFileURL(absoluteMediaPath(model.projectRoot, path)).href),
+      rateNode(),
+    ];
+    if (typeof known === "number") children.push(element("duration", {}, [], String(toFrame(known))));
+    children.push(element("media", {}, [
+      ...(audioOnly ? [] : [element("video", {}, [element("samplecharacteristics", {}, [
+        element("width", {}, [], String(Math.round(model.output.width))),
+        element("height", {}, [], String(Math.round(model.output.height))),
+      ])])]),
+      element("audio", {}, [element("samplecharacteristics", {}, [
+        element("samplerate", {}, [], "48000"),
+        element("depth", {}, [], "16"),
+      ])]),
+    ]));
+    return element("file", { id }, children);
+  };
+
+  // --- video tracks -----------------------------------------------------------
+  let clipSerial = 0;
+  const clipId = () => `clipitem-${clipSerial += 1}`;
+
+  const videoTracks = [];
+  const cutTrackIndexes = [...new Set(model.cuts.map((cut) => (Number.isInteger(cut.track) && cut.track >= 0 ? cut.track : 0)))].sort((a, b) => a - b);
+  for (const trackIndex of cutTrackIndexes.length > 0 ? cutTrackIndexes : []) {
+    const items = [];
+    model.cuts.forEach((cut, index) => {
+      const cutTrack = Number.isInteger(cut.track) && cut.track >= 0 ? cut.track : 0;
+      if (cutTrack !== trackIndex) return;
+      const placement = model.placements[index];
+      const boundary = !model.gapAware && cut.transition_out && index + 1 < model.cuts.length
+        ? cut.transition_out
+        : null;
+      const visibleDuration = boundary ? placement.duration - boundary.duration : placement.duration;
+      items.push(cutClipItem(model, cut, index, placement, visibleDuration, {
+        toFrame, rateNode, fileNode, clipId, warnings,
+      }));
+      if (boundary) {
+        const junction = placement.start + visibleDuration;
+        items.push(transitionItem(boundary, junction, { toFrame, rateNode }));
+        if (boundary.type !== "dissolve") {
+          dropped.push({
+            field: `cuts[${index}].transition_out.type`,
+            reason: `${boundary.type} は Cross Dissolve で近似する`,
+            hint: "書き出し先で Dip to Black/White へ差し替える",
+          });
+        }
+      }
+    });
+    videoTracks.push(element("track", {}, items));
+  }
+  if (model.gapAware && model.cuts.some((cut) => cut.transition_out)) {
+    dropped.push({
+      field: "cuts[].transition_out",
+      reason: "at / track 指定のあるタイムラインではトランジション境界が隣接に限らないため書き出さない",
+      hint: "書き出し先で手動でトランジションを追加する",
+    });
+  }
+  const layerTracks = [...new Set(model.layers.map((layer) => (Number.isInteger(layer.track) && layer.track >= 0 ? layer.track : 0)))].sort((a, b) => a - b);
+  for (const trackIndex of layerTracks) {
+    const items = model.layers
+      .filter((layer) => (Number.isInteger(layer.track) && layer.track >= 0 ? layer.track : 0) === trackIndex)
+      .map((layer) => layerClipItem(model, layer, { toFrame, rateNode, fileNode, clipId, warnings }));
+    videoTracks.push(element("track", {}, items));
+  }
+
+  // --- audio tracks -----------------------------------------------------------
+  const audioTracks = [];
+  if (model.narration.length > 0) {
+    audioTracks.push(element("track", {}, model.narration.map((item) => {
+      const duration = durations.get(item.path) ?? placeholder(item.path, "narration", warnings);
+      return audioClipItem(item.id, item.path, {
+        timelineStart: item.t,
+        timelineDuration: duration,
+        sourceIn: 0,
+        gainDb: item.gain_db,
+        fades: null,
+      }, { toFrame, rateNode, fileNode, clipId });
+    })));
+  }
+  const sfxTrackIndexes = [...new Set((model.sfx ?? []).map((item) => (Number.isInteger(item.track) && item.track >= 0 ? item.track : 0)))].sort((a, b) => a - b);
+  for (const trackIndex of sfxTrackIndexes) {
+    const items = (model.sfx ?? [])
+      .filter((item) => (Number.isInteger(item.track) && item.track >= 0 ? item.track : 0) === trackIndex)
+      .map((item) => {
+        const inPoint = typeof item.in === "number" ? item.in : 0;
+        const duration = typeof item.out === "number"
+          ? item.out - inPoint
+          : (durations.get(item.path) ?? placeholder(item.path, "sfx", warnings)) - inPoint;
+        return audioClipItem(item.path.split("/").pop(), item.path, {
+          timelineStart: item.t,
+          timelineDuration: Math.max(duration, 1 / fps),
+          sourceIn: inPoint,
+          gainDb: item.gain_db,
+          fades: null,
+        }, { toFrame, rateNode, fileNode, clipId });
+      });
+    audioTracks.push(element("track", {}, items));
+  }
+  if (model.bgm) {
+    audioTracks.push(element("track", {}, bgmClipItems(model, {
+      durations, totalDuration, toFrame, rateNode, fileNode, clipId, warnings, fps,
+    })));
+  }
+
+  // --- sequence markers（beats / emphasis_words を timeline へ写す）--------------
+  const markers = [];
+  for (const beat of model.beats) {
+    const src = typeof beat.src === "string" ? beat.src : null;
+    const mapped = mapAnchor(model, beat.t, src);
+    if (mapped === null) {
+      dropped.push({ field: `beats[${beat.id}]`, reason: "アンカーがどのカットにも含まれない", hint: "カット範囲外のマーカーは書き出されない" });
+      continue;
+    }
+    markers.push(sequenceMarker(`beat:${beat.kind} (${beat.strength})`, beat.basis ?? "", mapped, null, toFrame));
+  }
+  for (const word of model.emphasisWords) {
+    const src = typeof word.src === "string" ? word.src : null;
+    const mappedStart = mapAnchor(model, word.t_start, src);
+    if (mappedStart === null) {
+      dropped.push({ field: `emphasis_words[${word.id}]`, reason: "アンカーがどのカットにも含まれない", hint: "カット範囲外のマーカーは書き出されない" });
+      continue;
+    }
+    const mappedEnd = mapAnchor(model, word.t_end, src);
+    markers.push(sequenceMarker(
+      `emphasis:${word.word}`,
+      [word.emotion, word.style_hint].filter(Boolean).join(" / "),
+      mappedStart,
+      mappedEnd,
+      toFrame,
+    ));
+  }
+
+  const sequence = element("sequence", { id: "sequence-1" }, [
+    element("name", {}, [], model.projectName),
+    element("duration", {}, [], String(toFrame(totalDuration))),
+    rateNode(),
+    element("media", {}, [
+      element("video", {}, [
+        element("format", {}, [element("samplecharacteristics", {}, [
+          element("width", {}, [], String(Math.round(model.output.width))),
+          element("height", {}, [], String(Math.round(model.output.height))),
+          element("pixelaspectratio", {}, [], "square"),
+          rateNode(),
+        ])]),
+        ...videoTracks,
+      ]),
+      element("audio", {}, audioTracks),
+    ]),
+    element("timecode", {}, [
+      rateNode(),
+      element("frame", {}, [], "0"),
+      element("displayformat", {}, [], rate.ntsc ? "DF" : "NDF"),
+    ]),
+    ...markers,
+  ]);
+
+  const root = element("xmeml", { version: "5" }, [sequence]);
+  return { xml: xmlDocument(root, "<!DOCTYPE xmeml>"), dropped, warnings };
+}
+
+function cutClipItem(model, cut, index, placement, visibleDuration, context) {
+  const { toFrame, rateNode, fileNode, clipId, warnings } = context;
+  const speed = cutSpeed(cut);
+  const path = model.sources.find((source) => source.id === cut.src)?.path;
+  const filters = [];
+  if (cut.transform) filters.push(basicMotionFilter(cut.transform, model.output));
+  if (typeof cut.opacity === "number" && cut.opacity < 1) filters.push(opacityFilter(cut.opacity));
+  if (speed !== 1) {
+    // ⚠ 未検証: FCP7 流儀の timeremap 定速。Premiere は speed パラメータ（%）を読む
+    warnings.push(`cuts[${index}] speed=${speed} を timeremap 定速で書き出す（未検証）`);
+    filters.push(element("filter", {}, [element("effect", {}, [
+      element("name", {}, [], "Time Remap"),
+      element("effectid", {}, [], "timeremap"),
+      element("effectcategory", {}, [], "motion"),
+      element("effecttype", {}, [], "motion"),
+      element("mediatype", {}, [], "video"),
+      element("parameter", {}, [
+        element("parameterid", {}, [], "variablespeed"),
+        element("name", {}, [], "variablespeed"),
+        element("valuemin", {}, [], "0"),
+        element("valuemax", {}, [], "1"),
+        element("value", {}, [], "0"),
+      ]),
+      element("parameter", {}, [
+        element("parameterid", {}, [], "speed"),
+        element("name", {}, [], "speed"),
+        element("valuemin", {}, [], "-100000"),
+        element("valuemax", {}, [], "100000"),
+        element("value", {}, [], num(speed * 100)),
+      ]),
+    ])]));
+  }
+  return element("clipitem", { id: clipId() }, [
+    element("name", {}, [], `${cut.src} ${index + 1}`),
+    element("enabled", {}, [], "TRUE"),
+    element("duration", {}, [], String(toFrame(visibleDuration))),
+    rateNode(),
+    element("start", {}, [], String(toFrame(placement.start))),
+    element("end", {}, [], String(toFrame(placement.start + visibleDuration))),
+    element("in", {}, [], String(toFrame(cut.in))),
+    element("out", {}, [], String(toFrame(cut.in + visibleDuration * speed))),
+    fileNode(path),
+    ...filters,
+  ]);
+}
+
+function layerClipItem(model, layer, context) {
+  const { toFrame, rateNode, fileNode, clipId, warnings } = context;
+  const filters = [];
+  if (layer.transform) filters.push(basicMotionFilter(layer.transform, model.output));
+  if (typeof layer.opacity === "number" && layer.opacity < 1) filters.push(opacityFilter(layer.opacity));
+  if (typeof layer.blend === "string" && layer.blend !== "normal") {
+    warnings.push(`layers[${layer.id}] blend=${layer.blend} は xmeml に相互運用表現がなく落ちる（合成モードは書き出し先で再設定）`);
+  }
+  return element("clipitem", { id: clipId() }, [
+    element("name", {}, [], layer.id),
+    element("enabled", {}, [], "TRUE"),
+    element("duration", {}, [], String(toFrame(layer.duration))),
+    rateNode(),
+    element("start", {}, [], String(toFrame(layer.t))),
+    element("end", {}, [], String(toFrame(layer.t + layer.duration))),
+    element("in", {}, [], "0"),
+    element("out", {}, [], String(toFrame(layer.duration))),
+    fileNode(layer.src),
+    ...filters,
+  ]);
+}
+
+function audioClipItem(name, path, placement, context) {
+  const { toFrame, rateNode, fileNode, clipId } = context;
+  const filters = [];
+  if (placement.fades) {
+    filters.push(audioLevelsFilter(null, placement.fades, toFrame));
+  } else if (typeof placement.gainDb === "number" && placement.gainDb !== 0) {
+    filters.push(audioLevelsFilter(placement.gainDb, null, toFrame));
+  }
+  return element("clipitem", { id: clipId() }, [
+    element("name", {}, [], name),
+    element("enabled", {}, [], "TRUE"),
+    element("duration", {}, [], String(toFrame(placement.timelineDuration))),
+    rateNode(),
+    element("start", {}, [], String(toFrame(placement.timelineStart))),
+    element("end", {}, [], String(toFrame(placement.timelineStart + placement.timelineDuration))),
+    element("in", {}, [], String(toFrame(placement.sourceIn))),
+    element("out", {}, [], String(toFrame(placement.sourceIn + placement.timelineDuration))),
+    fileNode(path),
+    ...filters,
+  ]);
+}
+
+function bgmClipItems(model, context) {
+  const { durations, totalDuration, toFrame, rateNode, fileNode, clipId, warnings, fps } = context;
+  const bgm = model.bgm;
+  const assetDuration = durations.get(bgm.path);
+  const inPoint = typeof bgm.in === "number" ? bgm.in : 0;
+  const fadeIn = typeof bgm.fadeIn === "number" ? bgm.fadeIn : 0;
+  const fadeOut = typeof bgm.fadeOut === "number" ? bgm.fadeOut : 0;
+  const gain = typeof bgm.gain_db === "number" ? bgm.gain_db : 0;
+  const pieces = [];
+  if (typeof assetDuration === "number" && assetDuration > 0) {
+    let covered = 0;
+    let first = true;
+    while (covered < totalDuration - 1 / fps / 2) {
+      const start = first ? Math.min(inPoint, assetDuration) : 0;
+      const duration = Math.min(assetDuration - start, totalDuration - covered);
+      if (duration <= 0) break;
+      pieces.push({ offset: covered, start, duration });
+      covered += duration;
+      first = false;
+    }
+  } else {
+    warnings.push(`bgm の実尺が不明（ffprobe 不使用/失敗）— ループ展開せず全体尺 1 クリップで書き出す: ${bgm.path}`);
+    pieces.push({ offset: 0, start: inPoint, duration: totalDuration });
+  }
+  return pieces.map((piece, index) => {
+    const isFirst = index === 0;
+    const isLast = index === pieces.length - 1;
+    const keyframes = [];
+    if (isFirst && fadeIn > 0) {
+      keyframes.push({ at: 0, db: -96 }, { at: Math.min(fadeIn, piece.duration), db: gain });
+    }
+    if (isLast && fadeOut > 0) {
+      keyframes.push({ at: Math.max(0, piece.duration - fadeOut), db: gain }, { at: piece.duration, db: -96 });
+    }
+    return audioClipItem(
+      `bgm${pieces.length > 1 ? ` (loop ${index + 1})` : ""}`,
+      bgm.path,
+      {
+        timelineStart: piece.offset,
+        timelineDuration: piece.duration,
+        sourceIn: piece.start,
+        gainDb: gain,
+        fades: keyframes.length > 0 ? { keyframes, gainDb: gain } : null,
+      },
+      { toFrame, rateNode, fileNode, clipId },
+    );
+  });
+}
+
+// dB → xmeml audiolevels の線形値（1.0 = 0dB）。
+function dbToLevel(db) {
+  return 10 ** (db / 20);
+}
+
+function audioLevelsFilter(gainDb, fades, toFrame) {
+  const parameterChildren = [
+    element("parameterid", {}, [], "level"),
+    element("name", {}, [], "Level"),
+    element("valuemin", {}, [], "0"),
+    element("valuemax", {}, [], "3.980469"),
+  ];
+  if (fades) {
+    for (const keyframe of fades.keyframes) {
+      parameterChildren.push(element("keyframe", {}, [
+        element("when", {}, [], String(toFrame(keyframe.at))),
+        element("value", {}, [], dbToLevel(keyframe.db).toFixed(6)),
+      ]));
+    }
+  } else {
+    parameterChildren.push(element("value", {}, [], dbToLevel(gainDb).toFixed(6)));
+  }
+  return element("filter", {}, [element("effect", {}, [
+    element("name", {}, [], "Audio Levels"),
+    element("effectid", {}, [], "audiolevels"),
+    element("effectcategory", {}, [], "audiolevels"),
+    element("effecttype", {}, [], "audiolevels"),
+    element("mediatype", {}, [], "audio"),
+    element("parameter", {}, parameterChildren),
+  ])]);
+}
+
+function basicMotionFilter(transform, output) {
+  const x = typeof transform.x === "number" ? transform.x : 0;
+  const y = typeof transform.y === "number" ? transform.y : 0;
+  const scale = typeof transform.scale === "number" ? transform.scale : 1;
+  const rotate = typeof transform.rotate === "number" ? transform.rotate : 0;
+  // ⚠ 未検証: center は画面幅/高さで正規化した相対値（Premiere の xmeml 観察に基づく）
+  return element("filter", {}, [element("effect", {}, [
+    element("name", {}, [], "Basic Motion"),
+    element("effectid", {}, [], "basic"),
+    element("effectcategory", {}, [], "motion"),
+    element("effecttype", {}, [], "motion"),
+    element("mediatype", {}, [], "video"),
+    element("parameter", {}, [
+      element("parameterid", {}, [], "scale"),
+      element("name", {}, [], "Scale"),
+      element("valuemin", {}, [], "0"),
+      element("valuemax", {}, [], "1000"),
+      element("value", {}, [], num(scale * 100)),
+    ]),
+    element("parameter", {}, [
+      element("parameterid", {}, [], "rotation"),
+      element("name", {}, [], "Rotation"),
+      element("valuemin", {}, [], "-8640"),
+      element("valuemax", {}, [], "8640"),
+      element("value", {}, [], num(rotate)),
+    ]),
+    element("parameter", {}, [
+      element("parameterid", {}, [], "center"),
+      element("name", {}, [], "Center"),
+      element("value", {}, [
+        element("horiz", {}, [], num(x / output.width)),
+        element("vert", {}, [], num(y / output.height)),
+      ]),
+    ]),
+  ])]);
+}
+
+function opacityFilter(opacity) {
+  return element("filter", {}, [element("effect", {}, [
+    element("name", {}, [], "Opacity"),
+    element("effectid", {}, [], "opacity"),
+    element("effectcategory", {}, [], "motion"),
+    element("effecttype", {}, [], "motion"),
+    element("mediatype", {}, [], "video"),
+    element("parameter", {}, [
+      element("parameterid", {}, [], "opacity"),
+      element("name", {}, [], "opacity"),
+      element("valuemin", {}, [], "0"),
+      element("valuemax", {}, [], "100"),
+      element("value", {}, [], num(opacity * 100)),
+    ]),
+  ])]);
+}
+
+function transitionItem(boundary, junction, { toFrame, rateNode }) {
+  const half = boundary.duration / 2;
+  return element("transitionitem", {}, [
+    rateNode(),
+    element("start", {}, [], String(Math.max(0, toFrame(junction - half)))),
+    element("end", {}, [], String(toFrame(junction + half))),
+    element("alignment", {}, [], "center"),
+    element("effect", {}, [
+      element("name", {}, [], "Cross Dissolve"),
+      element("effectid", {}, [], "Cross Dissolve"),
+      element("effectcategory", {}, [], "Dissolve"),
+      element("effecttype", {}, [], "transition"),
+      element("mediatype", {}, [], "video"),
+      element("wipecode", {}, [], "0"),
+      element("wipeaccuracy", {}, [], "100"),
+      element("startratio", {}, [], "0"),
+      element("endratio", {}, [], "1"),
+      element("reverse", {}, [], "FALSE"),
+    ]),
+  ]);
+}
+
+function sequenceMarker(name, comment, startSeconds, endSeconds, toFrame) {
+  return element("marker", {}, [
+    element("comment", {}, [], comment),
+    element("name", {}, [], name),
+    element("in", {}, [], String(toFrame(startSeconds))),
+    element("out", {}, [], endSeconds === null ? "-1" : String(toFrame(endSeconds))),
+  ]);
+}
+
+// (src, source 秒) アンカー → timeline 秒（xmeml はシーケンスマーカーなので単点写像だけ使う）。
+function mapAnchor(model, t, src) {
+  return sourcePointToTimeline(t, model.cuts, src);
+}
+
+function placeholder(path, role, warnings) {
+  warnings.push(`${role} の実尺が不明（ffprobe 不使用/失敗）— ${PLACEHOLDER_AUDIO_SECONDS}s のプレースホルダ尺で書き出す: ${path}`);
+  return PLACEHOLDER_AUDIO_SECONDS;
+}

--- a/packages/export-nle/src/xml.mjs
+++ b/packages/export-nle/src/xml.mjs
@@ -1,0 +1,38 @@
+// 依存ゼロの XML 組み立てヘルパ。writer 2 本（fcpxml / xmeml）で共用する。
+
+export function escapeXml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// タグ名・属性・子要素から整形済み XML を組む。children は文字列（既整形）か
+// node オブジェクトの配列。text は要素内テキスト（escape される）。
+export function element(name, attributes = {}, children = [], text = null) {
+  return { name, attributes, children, text };
+}
+
+export function serialize(node, indent = 0) {
+  const pad = "  ".repeat(indent);
+  const attrs = Object.entries(node.attributes)
+    .filter(([, value]) => value !== null && value !== undefined)
+    .map(([key, value]) => ` ${key}="${escapeXml(value)}"`)
+    .join("");
+  if (node.text !== null && node.text !== undefined) {
+    return `${pad}<${node.name}${attrs}>${escapeXml(node.text)}</${node.name}>`;
+  }
+  const children = (node.children ?? []).filter(Boolean);
+  if (children.length === 0) return `${pad}<${node.name}${attrs}/>`;
+  const body = children
+    .map((child) => (typeof child === "string" ? child : serialize(child, indent + 1)))
+    .join("\n");
+  return `${pad}<${node.name}${attrs}>\n${body}\n${pad}</${node.name}>`;
+}
+
+export function document(root, doctype = null) {
+  const header = '<?xml version="1.0" encoding="UTF-8"?>';
+  return `${header}\n${doctype ? `${doctype}\n` : ""}${serialize(root)}\n`;
+}

--- a/packages/export-nle/test/cli.test.mjs
+++ b/packages/export-nle/test/cli.test.mjs
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertWellFormedXml } from "./helpers.mjs";
+
+const bin = resolve(dirname(fileURLToPath(import.meta.url)), "..", "bin", "export-nle.mjs");
+
+function makeProject() {
+  const root = mkdtempSync(join(tmpdir(), "export-nle-"));
+  writeFileSync(join(root, "edit.json"), JSON.stringify({
+    version: 0,
+    output: { width: 1280, height: 720, fps: 30 },
+    source: { path: "source.mp4", proxy: null },
+    cuts: [
+      { in: 0, out: 5 },
+      { in: 10, out: 12, transform: { scale: 1.1 } },
+    ],
+    audio: {
+      narration: [
+        { id: "n-0001", path: "n.mp3", t: 1, provenance: { provider: "human" } },
+      ],
+      bgm: { path: "bgm.mp3", gain_db: -12, ducking: true },
+    },
+  }, null, 2));
+  writeFileSync(join(root, "captions.json"), JSON.stringify([
+    { id: "c-0001", start: 0.5, end: 2, text: "テスト字幕", speaker: null, sourceRef: null, edited: false },
+  ]));
+  return root;
+}
+
+test("CLI: --no-probe --json で 3 形式 + レポートを書き出し exit 0", () => {
+  const root = makeProject();
+  const result = spawnSync(process.execPath, [bin, root, "--no-probe", "--json"], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.status, "beta-unverified");
+  assert.equal(report.probed, false);
+  assert.equal(report.written.length, 3);
+  assert.ok(report.dropped.some((entry) => entry.field === "audio.bgm.ducking"));
+  // プレースホルダ尺の warning が出ている（黙って推測しない）
+  assert.ok(report.warnings.some((warning) => warning.includes("実尺が不明")));
+
+  const outDir = join(root, "exports", "nle");
+  const name = root.split("/").pop();
+  for (const file of [`${name}.fcpxml`, `${name}.premiere.xml`, `${name}.srt`, "export-report.json"]) {
+    assert.ok(existsSync(join(outDir, file)), `missing ${file}`);
+  }
+  assertWellFormedXml(readFileSync(join(outDir, `${name}.fcpxml`), "utf8"));
+  assertWellFormedXml(readFileSync(join(outDir, `${name}.premiere.xml`), "utf8"));
+  const srt = readFileSync(join(outDir, `${name}.srt`), "utf8");
+  assert.match(srt, /00:00:00,500 --> 00:00:02,000\nテスト字幕/);
+});
+
+test("CLI: 不正入力は exit 2", () => {
+  const result = spawnSync(process.execPath, [bin, "/nonexistent/path"], { encoding: "utf8" });
+  assert.equal(result.status, 2);
+});
+
+test("CLI: --format srt だけの選択実行", () => {
+  const root = makeProject();
+  const result = spawnSync(process.execPath, [bin, root, "--no-probe", "--format", "srt", "--json"], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.written.length, 1);
+  assert.equal(report.written[0].format, "srt");
+});

--- a/packages/export-nle/test/edit-model.test.mjs
+++ b/packages/export-nle/test/edit-model.test.mjs
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  normalizeEdit,
+  computeCutTimelineOffsets,
+  needsGapAwareCutTimeline,
+  sourceRangeToTimelineRanges,
+  sourcePointToTimeline,
+  baseTimelineDuration,
+  V0_SOURCE_ID,
+} from "../src/edit-model.mjs";
+
+const v1Edit = {
+  version: 1,
+  output: { width: 1080, height: 1920, fps: 30 },
+  sources: [{ id: "main", path: "main.mp4", proxy: null }],
+  cuts: [
+    { src: "main", in: 0, out: 5, transition_out: { type: "dissolve", duration: 1 } },
+    { src: "main", in: 10, out: 15, speed: 2 },
+  ],
+};
+
+test("normalizeEdit: v0 は単一 source を合成 id で v1 相当へ", () => {
+  const model = normalizeEdit({
+    version: 0,
+    output: { width: 1280, height: 720, fps: 30 },
+    source: { path: "source.mp4" },
+    cuts: [{ in: 0, out: 5 }],
+  }, "/tmp/proj");
+  assert.equal(model.sources[0].id, V0_SOURCE_ID);
+  assert.equal(model.cuts[0].src, V0_SOURCE_ID);
+  assert.equal(model.projectName, "proj");
+});
+
+test("computeCutTimelineOffsets: xfade 重複を差し引いた逐次連結（render-cut と同意味論）", () => {
+  const model = normalizeEdit(v1Edit, "/tmp/proj");
+  // cut1: 5s、xfade 1s → cut2 は 4s から。cut2 は speed 2 で 2.5s
+  assert.deepEqual(model.placements, [
+    { start: 0, duration: 5 },
+    { start: 4, duration: 2.5 },
+  ]);
+  assert.equal(baseTimelineDuration(model), 6.5);
+  assert.equal(model.gapAware, false);
+});
+
+test("needsGapAwareCutTimeline: at / track 指定で true", () => {
+  assert.equal(needsGapAwareCutTimeline([{ in: 0, out: 5 }]), false);
+  assert.equal(needsGapAwareCutTimeline([{ in: 0, out: 5, at: 2 }]), true);
+  assert.equal(needsGapAwareCutTimeline([{ in: 0, out: 5, track: 1 }]), true);
+});
+
+test("sourceRangeToTimelineRanges: source 秒アンカーを speed 込みで timeline へ写す", () => {
+  const model = normalizeEdit(v1Edit, "/tmp/proj");
+  // source [11,12) は cut2（in 10 / speed 2）内 → timeline 4 + 0.5 から 0.5s
+  const ranges = sourceRangeToTimelineRanges(11, 12, model.cuts, "main");
+  assert.equal(ranges.length, 1);
+  assert.equal(ranges[0].start, 4.5);
+  assert.equal(ranges[0].duration, 0.5);
+});
+
+test("sourceRangeToTimelineRanges: カットを跨ぐ範囲は複数レンジに割れる", () => {
+  const cuts = [
+    { src: "main", in: 0, out: 5 },
+    { src: "main", in: 10, out: 15 },
+  ];
+  const ranges = sourceRangeToTimelineRanges(4, 11, cuts, "main");
+  assert.equal(ranges.length, 2);
+  assert.deepEqual(ranges.map((range) => [range.start, range.duration]), [[4, 1], [5, 1]]);
+});
+
+test("sourcePointToTimeline: どのカットにも含まれなければ null", () => {
+  const model = normalizeEdit(v1Edit, "/tmp/proj");
+  assert.equal(sourcePointToTimeline(2, model.cuts, "main"), 2);
+  assert.equal(sourcePointToTimeline(7, model.cuts, "main"), null);
+  assert.equal(sourcePointToTimeline(2, model.cuts, "other"), null);
+});

--- a/packages/export-nle/test/helpers.mjs
+++ b/packages/export-nle/test/helpers.mjs
@@ -1,0 +1,29 @@
+// テスト用の最小 XML well-formed 検査（依存ゼロ規律のため自前実装）。
+// タグの開閉対応・属性引用符・未エスケープ & のみを見る。DTD 検証はしない。
+
+import assert from "node:assert/strict";
+
+export function assertWellFormedXml(xml) {
+  let rest = xml.replace(/^<\?xml[^>]*\?>\s*/, "").replace(/^<!DOCTYPE[^>]*>\s*/, "");
+  const stack = [];
+  const tagPattern = /<(\/?)([A-Za-z][\w.-]*)((?:\s+[\w.-]+="[^"]*")*)\s*(\/?)>|([^<]+)/g;
+  let match;
+  let consumed = 0;
+  while ((match = tagPattern.exec(rest)) !== null) {
+    assert.equal(match.index, consumed, `XML として解釈できない断片: ${rest.slice(consumed, consumed + 80)}`);
+    consumed = match.index + match[0].length;
+    const [, closing, name, , selfClosing, text] = match;
+    if (text !== undefined) {
+      assert.ok(!/&(?!amp;|lt;|gt;|quot;|apos;|#\d+;)/.test(text), `未エスケープの & がある: ${text.slice(0, 60)}`);
+      continue;
+    }
+    if (closing) {
+      const opened = stack.pop();
+      assert.equal(opened, name, `閉じタグ不一致: 開 ${opened} / 閉 ${name}`);
+    } else if (!selfClosing) {
+      stack.push(name);
+    }
+  }
+  assert.equal(consumed, rest.length, `末尾に解釈できない断片が残る: ${rest.slice(consumed, consumed + 80)}`);
+  assert.deepEqual(stack, [], `閉じられていないタグ: ${stack.join(" > ")}`);
+}

--- a/packages/export-nle/test/time.test.mjs
+++ b/packages/export-nle/test/time.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { frameDuration, fcpTime, fcpFrameDuration, toFrames, srtTime, xmemlRate } from "../src/time.mjs";
+
+test("frameDuration: NTSC 系は 1001 系有理数へ", () => {
+  assert.deepEqual(frameDuration(29.97), { numerator: 1001, denominator: 30000 });
+  assert.deepEqual(frameDuration(23.976), { numerator: 1001, denominator: 24000 });
+  assert.deepEqual(frameDuration(59.94), { numerator: 1001, denominator: 60000 });
+});
+
+test("frameDuration: 整数 fps は 1/fps", () => {
+  assert.deepEqual(frameDuration(30), { numerator: 1, denominator: 30 });
+  assert.deepEqual(frameDuration(24), { numerator: 1, denominator: 24 });
+});
+
+test("fcpTime: フレーム境界へ量子化して約分する", () => {
+  const fd30 = frameDuration(30);
+  assert.equal(fcpTime(0, fd30), "0s");
+  assert.equal(fcpTime(5, fd30), "5s");
+  assert.equal(fcpTime(1 / 3, fd30), "1/3s");
+  assert.equal(fcpTime(3.5, fd30), "7/2s");
+  // 30fps のフレーム境界に乗らない値は最近傍フレームへ
+  assert.equal(fcpTime(0.034, fd30), "1/30s");
+  const ntsc = frameDuration(29.97);
+  assert.equal(fcpTime(1001 / 30000, ntsc), "1001/30000s");
+  assert.equal(fcpFrameDuration(ntsc), "1001/30000s");
+});
+
+test("toFrames: NTSC の丸めがドリフトしない", () => {
+  const ntsc = frameDuration(29.97);
+  // 60 秒 = 1798.2 フレーム → 1798（29.97 の実フレーム数）
+  assert.equal(toFrames(60, ntsc), Math.round((60 * 30000) / 1001));
+});
+
+test("srtTime: HH:MM:SS,mmm 形式", () => {
+  assert.equal(srtTime(0), "00:00:00,000");
+  assert.equal(srtTime(1.5), "00:00:01,500");
+  assert.equal(srtTime(3661.042), "01:01:01,042");
+});
+
+test("xmemlRate: NTSC は整数 timebase + ntsc TRUE", () => {
+  assert.deepEqual(xmemlRate(29.97), { timebase: 30, ntsc: true });
+  assert.deepEqual(xmemlRate(23.976), { timebase: 24, ntsc: true });
+  assert.deepEqual(xmemlRate(30), { timebase: 30, ntsc: false });
+  assert.deepEqual(xmemlRate(25), { timebase: 25, ntsc: false });
+});

--- a/packages/export-nle/test/writers.test.mjs
+++ b/packages/export-nle/test/writers.test.mjs
@@ -1,0 +1,121 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { normalizeEdit, baseTimelineDuration } from "../src/edit-model.mjs";
+import { frameDuration } from "../src/time.mjs";
+import { buildFcpxml } from "../src/fcpxml.mjs";
+import { buildXmeml } from "../src/xmeml.mjs";
+import { buildSrt } from "../src/srt.mjs";
+import { assertWellFormedXml } from "./helpers.mjs";
+
+const edit = {
+  version: 1,
+  output: { width: 1080, height: 1920, fps: 30 },
+  sources: [{ id: "main", path: "main.mp4", proxy: null }],
+  cuts: [
+    { src: "main", in: 0, out: 5, transition_out: { type: "dissolve", duration: 1 } },
+    { src: "main", in: 10, out: 15, speed: 2, transform: { x: 10, y: -20, scale: 1.2 }, opacity: 0.9 },
+  ],
+  layers: [
+    { id: "l-0001", t: 1, duration: 2, kind: "baked", src: "telop.mov", opacity: 0.8, blend: "screen" },
+  ],
+  audio: {
+    narration: [
+      { id: "n-0001", path: "narration/n-0001.mp3", t: 1, gain_db: -3, provenance: { provider: "human" } },
+    ],
+    bgm: { path: "bgm.mp3", gain_db: -18, ducking: true, fadeOut: 2 },
+    sfx: [{ path: "sfx/hit.wav", t: 2, in: 0.5, out: 1.5, gain_db: -6 }],
+    master: { loudnorm: -14 },
+  },
+  beats: [{ id: "b-0001", src: "main", t: 2, kind: "hook", strength: 0.8 }],
+  emphasis_words: [
+    { id: "e-0001", src: "main", t_start: 11, t_end: 11.5, word: "ここ", emotion: "surprise" },
+    { id: "e-0002", src: "main", t_start: 7, t_end: 7.5, word: "圏外", emotion: "joy" },
+  ],
+  direction: { preset: "shorts-high-energy", intensity: 70 },
+};
+
+function buildContext(model) {
+  return {
+    durations: new Map([
+      ["main.mp4", 20],
+      ["bgm.mp3", 4],
+      ["narration/n-0001.mp3", 2],
+      ["sfx/hit.wav", 3],
+      ["telop.mov", 2],
+    ]),
+    frameDur: frameDuration(model.output.fps),
+    totalDuration: baseTimelineDuration(model),
+  };
+}
+
+test("fcpxml: well-formed で、主要素と時刻が量子化有理数で入る", () => {
+  const model = normalizeEdit(edit, "/tmp/demo-project");
+  const { xml, dropped } = buildFcpxml(model, buildContext(model));
+  assertWellFormedXml(xml);
+  assert.match(xml, /<fcpxml version="1\.11">/);
+  assert.match(xml, /frameDuration="1\/30s"/);
+  // xfade: cut1 可視尺 4s → junction 4s、中央寄せで offset 3.5s
+  assert.match(xml, /<transition name="Cross Dissolve" offset="7\/2s" duration="1s"\/>/);
+  // beat は含むカットのクリップへ source 秒のまま marker
+  assert.match(xml, /<marker start="2s"[^>]*value="beat:hook \(0\.8\)"/);
+  // BGM は実尺 4s → 全体尺 6.5s を 2 ループで充填
+  assert.match(xml, /name="bgm \(loop 1\)"/);
+  assert.match(xml, /name="bgm \(loop 2\)"/);
+  // ゲインは adjust-volume
+  assert.match(xml, /<adjust-volume amount="-3dB"\/>/);
+  assert.match(xml, /audioRole="dialogue"/);
+});
+
+test("fcpxml: 移らないフィールドが dropped に列挙される（黙って落とさない）", () => {
+  const model = normalizeEdit(edit, "/tmp/demo-project");
+  const { dropped } = buildFcpxml(model, buildContext(model));
+  const fields = dropped.map((entry) => entry.field);
+  assert.ok(fields.includes("audio.bgm.ducking"));
+  assert.ok(fields.includes("audio.master"));
+  assert.ok(fields.includes("direction"));
+  // カット範囲外の emphasis はマーカーにならず dropped
+  assert.ok(fields.includes("emphasis_words[e-0002]"));
+});
+
+test("xmeml: well-formed で、フレーム整数と NTSC フラグが正しい", () => {
+  const model = normalizeEdit(edit, "/tmp/demo-project");
+  const { xml } = buildXmeml(model, buildContext(model));
+  assertWellFormedXml(xml);
+  assert.match(xml, /<xmeml version="5">/);
+  assert.match(xml, /<timebase>30<\/timebase>/);
+  assert.match(xml, /<ntsc>FALSE<\/ntsc>/);
+  // cut1: start 0 / end 120（可視 4s @30fps）、transition は 105-135 中央寄せ
+  assert.match(xml, /<start>105<\/start>/);
+  assert.match(xml, /<end>135<\/end>/);
+  // -18dB → 線形 0.125893
+  assert.match(xml, /<value>0\.125893<\/value>/);
+  // speed 2 → timeremap 200%
+  assert.match(xml, /<effectid>timeremap<\/effectid>/);
+  assert.match(xml, /<value>200<\/value>/);
+  // beat はシーケンスマーカー
+  assert.match(xml, /<name>beat:hook \(0\.8\)<\/name>/);
+});
+
+test("xmeml: NTSC fps でフレームが真のレートで丸まる", () => {
+  const model = normalizeEdit({ ...edit, output: { width: 1080, height: 1920, fps: 29.97 } }, "/tmp/p");
+  const { xml } = buildXmeml(model, buildContext(model));
+  assert.match(xml, /<ntsc>TRUE<\/ntsc>/);
+  // 4s @29.97 → 120 フレーム（4 * 30000/1001 = 119.88 → 120）
+  assert.match(xml, /<end>120<\/end>/);
+});
+
+test("srt: source 秒アンカーを timeline へ写した cue を出す", () => {
+  const model = normalizeEdit(edit, "/tmp/demo-project");
+  const captions = [
+    { id: "c-0001", start: 1, end: 3, text: "こんにちは", src: "main", speaker: null, sourceRef: null, edited: false },
+    { id: "c-0002", start: 11, end: 12, text: "スピード区間", src: "main", speaker: null, sourceRef: null, edited: false, style: "karaoke" },
+    { id: "c-0003", start: 7, end: 8, text: "カット圏外", src: "main", speaker: null, sourceRef: null, edited: false },
+  ];
+  const { srt, cueCount, dropped } = buildSrt(model, captions);
+  assert.equal(cueCount, 2);
+  assert.match(srt, /1\n00:00:01,000 --> 00:00:03,000\nこんにちは/);
+  // speed 2: source [11,12) → timeline 4.5 から 0.5s
+  assert.match(srt, /2\n00:00:04,500 --> 00:00:05,000\nスピード区間/);
+  assert.ok(!srt.includes("カット圏外"));
+  assert.ok(dropped.some((entry) => entry.field.startsWith("captions[]")));
+});

--- a/skills/export-nle/SKILL.md
+++ b/skills/export-nle/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: export-nle
+description: "BETA（実 NLE 取り込み未確認）: edit.json を Final Cut Pro / DaVinci Resolve（FCPXML）・Premiere Pro（FCP7 XML）・SRT 字幕へ書き出す。「Premiere で開きたい」「Final Cut に持っていきたい」「Resolve 用に書き出して」「SRT がほしい」で使う。移せないフィールドは dropped[] で必ず報告する。"
+---
+
+# 編集データを他社 NLE へ書き出す（BETA）
+
+> **Language**: Respond in the user's language — 対話・質問・承認確認・レポートはユーザーの使用言語に合わせる（例: 英語で話しかけられたら英語で応答する）。
+
+> ⚠ **BETA — 実装のみ・実アプリでの動作未確認**
+> この機能は「実装だけはしたが、生成物を実際の Final Cut Pro / DaVinci Resolve /
+> Premiere Pro に取り込む検証はまだ行っていない」段階で公開している。生成された
+> XML が取り込めない・ずれる等の報告は歓迎（issue へ）。ユーザーへ結果を渡すときは
+> **必ずこのベータ地位を伝える**こと。
+
+## これは何か
+
+AKARI Video のセーブデータ SSOT（edit.json）には lock-in がない、という証明としての
+**片道書き出し**。最後の仕上げをプロツールでやりたい人への出口を用意する。
+
+| 形式 | 対象 | ファイル |
+|---|---|---|
+| FCPXML 1.11 | Final Cut Pro / DaVinci Resolve | `<project>.fcpxml` |
+| FCP7 XML (xmeml v5) | Premiere Pro | `<project>.premiere.xml` |
+| SRT | 全 NLE 共通の字幕サイドカー | `<project>.srt`（captions.json があるときのみ） |
+
+**逆方向（NLE で編集した結果を edit.json へ戻す）は非対応**。スコープに含めない。
+
+## ハードルール
+
+1. **決定的であること**: 同一入力 → 同一出力。LLM 判断・乱数・現在時刻を出力に混ぜない
+2. **外部 npm 依存ゼロ**（ffprobe は media-bin 経由の本体直叩きのみ）
+3. **edit.json を書き換えない**。書き出しは読み取り専用の変換
+4. **黙って落とさない**: 交換形式に移せないフィールド（ducking / master / LUT /
+   chroma_key / direction 等）は `export-report.json` の `dropped[]` に全件列挙する
+5. **ベータ地位の明示**: ユーザーへの報告に「実 NLE での取り込みは未確認」を必ず含める。
+   検証済みかのように振る舞わない
+
+## 実行手順
+
+1. 対象プロジェクト（edit.json のあるディレクトリ）に対して実行する。
+
+   ```sh
+   node packages/export-nle/bin/export-nle.mjs <project-root|edit.json>
+   ```
+
+   既定の出力先は `<project>/exports/nle/`。形式を絞るときは `--format fcpxml`（カンマ区切り可）、
+   機械向け出力は `--json`、ffprobe を使わないときは `--no-probe`。
+
+2. exit code を確認する。`0` は書き出し完了（warnings があっても成功）、`2` は入力・実行環境エラー。
+3. `exports/nle/export-report.json` を読み、`dropped[]`（移らないフィールド）と `warnings[]`
+   （プレースホルダ尺・近似など）をユーザーへの報告に含める。
+4. メディアは**参照**で書かれる（絶対パスの file URL）。プロジェクトを移動・共有した場合は
+   NLE 側の relink 機能で再接続が必要、と案内する。
+
+## 何が移って何が移らないか（契約の要約）
+
+正本: [contract-2026-08-01-export-nle-beta.md](../../docs/contract-2026-08-01-export-nle-beta.md)
+
+- **移る**: cuts（at / track / in / out / speed / transform / opacity）、transition_out
+  （dissolve は素直に、fade-black/white は cross dissolve 近似）、layers（アルファ付き mov は
+  ただのクリップとして）、narration / sfx / bgm（配置 + gain。bgm はループ展開 + フェード）、
+  beats / emphasis_words（マーカーへ退化）、captions（SRT のプレーンテキストへ）
+- **移らない**（dropped[] で報告）: ducking、audio.master（loudnorm / denoise）、
+  output.look（LUT）、chroma_key、direction、字幕スタイル（カラオケ演出・座布団）
+
+## 非スコープ
+
+- CapCut の draft 形式（非公式・暗号化進行中・バージョン更新で壊れる前提のため見送り。
+  需要が出たら lab/ スパイクから）
+- NLE からの逆輸入（インポート）
+- 生成 XML の実アプリ取り込み検証の自動化（ベータ卒業の条件。手動検証の結果が集まってから設計する）


### PR DESCRIPTION
## 概要

edit.json の他社 NLE への**片道書き出し**を、オーナー裁定どおり **BETA（実装のみ・実アプリでの動作未確認）** として公開する。

| 出力 | 対象 |
|---|---|
| `<project>.fcpxml`（FCPXML 1.11） | Final Cut Pro / DaVinci Resolve |
| `<project>.premiere.xml`（FCP7 XML / xmeml v5） | Premiere Pro |
| `<project>.srt` | 全 NLE 共通字幕（captions.json 存在時） |
| `export-report.json` | written / dropped / warnings |

## 設計の要点

- **決定的 CLI・外部 npm 依存ゼロ**（ffprobe は media-bin 解決の本体直叩き、`--no-probe` で完全オフライン）
- 時間はフレーム境界へ量子化（NTSC 1001 系対応）。タイムライン意味論（speed / xfade 重複 / (src, source 秒) アンカー）は render-cut と同式の最小移植
- **黙って落とさない**: ducking / master / LUT / chroma_key / direction / 字幕スタイルは `dropped[]` に全件列挙
- ベータ地位の明示をスキルのハードルールに固定（「検証済みかのように振る舞わない」）
- ベータ卒業条件（実機取り込みの検証マトリクス）は契約文書 §7 にチェックリスト化

## 検証

- ユニットテスト 20 件 green（時間量子化 / アンカー写像 / writer 構造 well-formed / CLI smoke）
- `gen-skills-index --check` drift なし（18 スキル）
- test-project への実行 smoke（ffprobe 実尺込み）確認済み
- **実 FCP / Resolve / Premiere への取り込みは未検証**（それがこの PR の明示的な地位）

🤖 Generated with [Claude Code](https://claude.com/claude-code)