### PR TITLE
fix: Windows symlink fallback for workspace dependencies

### DIFF
--- a/apps/shell/resources/scripts/ensure-file-deps-linked.mjs
+++ b/apps/shell/resources/scripts/ensure-file-deps-linked.mjs
@@ -1,10 +1,20 @@
 import { lstat, mkdir, readFile, symlink } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+import { execSync } from 'node:child_process';
 
 const shellRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const packageJson = JSON.parse(await readFile(path.join(shellRoot, 'package.json'), 'utf8'));
 const dependencies = { ...packageJson.dependencies, ...packageJson.devDependencies };
+
+function isWindows() {
+  return os.platform() === 'win32';
+}
+
+function createSymlink(linkPath, targetPath) {
+  return symlink(path.relative(path.dirname(linkPath), targetPath), linkPath, 'dir');
+}
 
 for (const [name, specification] of Object.entries(dependencies)) {
   if (typeof specification !== 'string' || !specification.startsWith('file:')) {
@@ -16,7 +26,38 @@ for (const [name, specification] of Object.entries(dependencies)) {
   if (exists) {
     continue;
   }
+
   await mkdir(path.dirname(link), { recursive: true });
-  await symlink(path.relative(path.dirname(link), target), link, 'dir');
-  console.log(`linked: ${name} -> ${path.relative(shellRoot, target)}`);
+
+  // Windows-friendly symlink strategy:
+  // 1. Try normal symlink (works on Win10+ with admin/dev mode)
+  // 2. Fall back to junction (always works on Windows)
+  // 3. Fall back to copy (guaranteed but slowest)
+  const targetRelative = path.relative(path.dirname(link), target);
+  let success = false;
+
+  try {
+    await createSymlink(link, target);
+    console.log(`linked: ${name} -> ${path.relative(shellRoot, target)}`);
+    success = true;
+  } catch (e) {
+    if (!isWindows()) throw e;
+
+    // Fallback 1: junction (fs.symlink with 'dir' type should handle this, but try junction explicitly)
+    try {
+      await execSync(`mklink /J "${link}" "${target}"`, { stdio: 'ignore' });
+      console.log(`linked (junction): ${name} -> ${path.relative(shellRoot, target)}`);
+      success = true;
+    } catch (junctionErr) {
+      // Fallback 2: copy the directory (guaranteed to work, but slower)
+      const { execFileSync } = await import('node:child_process');
+      try {
+        await execSync(`xcopy /E /I /Q "${target}" "${link}"`, { stdio: 'ignore' });
+        console.log(`linked (copy): ${name} -> ${path.relative(shellRoot, target)}`);
+        success = true;
+      } catch (copyErr) {
+        throw new Error(`${name}: failed to link "${target}" to "${link}". Tried symlink, junction, copy. Last error: ${copyErr.message}`);
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Windows で  が  エラーになる問題を修正。 の workspace 依存（ 等の extensions）を  配下にリンクする際、管理者権限や開発者モードがなくても動作するようフォールバック戦略を実装。

## Changes

- : 3段階フォールバック追加
  1.  (正常系)
  2.  (Windows junction)
  3. 0 ̃t@CðRs[µ܂µ½ (完全コピー)

## Testing

-  実行 → 9 extensions 全て junction でリンク成功
- 元の EPERM エラー ( 等) が解消

## Motivation

Windows 環境では  配下へのシンボリックリンク作成に管理者権限が必要な場合があり、CI や開発環境でビルドが失敗していた。