### PR TITLE
[修正] GPU 書き出しの mux を MP4Box から ffmpeg remux へ — 2 GiB を超える長尺が 1 バイトも書けずに落ちるのを解消

### DIFF
--- a/packages/gpu-export/src/electron-main.mjs
+++ b/packages/gpu-export/src/electron-main.mjs
@@ -10,7 +10,7 @@ import { createMemorySampler, resolveMemoryBudget } from "../../osr-export/src/m
 import { encodeRgbaPng } from "../../osr-export/src/png.mjs";
 import { startStaticServer } from "../../osr-export/src/static-server.mjs";
 import { loadAndBuildGpuPage } from "./page-builder.mjs";
-import { muxMp4boxDirect } from "./mp4-mux.mjs";
+import { muxEncodedVideo } from "./mp4-mux.mjs";
 import { resolveGpuEncoding } from "./bitrate.mjs";
 import { CAPTION_MEASURE_UNSTABLE_REASON } from "./eligibility.mjs";
 
@@ -45,6 +45,7 @@ export async function runGpuExport(options) {
     captureOutputDirectory = null,
     processTimeoutMs = Math.max(300_000, frames * 1_000),
     ffprobeCommand = process.env.FFPROBE ?? process.env.AKARI_FFPROBE_BIN ?? "ffprobe",
+    ffmpegCommand = process.env.FFMPEG ?? process.env.AKARI_FFMPEG_BIN ?? "ffmpeg",
   } = options;
   const captureMode = captureFrames !== null;
   if (!Number.isFinite(duration) || duration <= 0 || !Number.isInteger(frames) || frames <= 0) {
@@ -181,14 +182,13 @@ export async function runGpuExport(options) {
     const state = chunkState;
     chunkState = null;
     await state.writeChain;
-    const mux = await muxMp4boxDirect({
+    const mux = await muxEncodedVideo({
       samples: state.samples,
       annexBPath,
       outputPath: out,
-      width,
-      height,
       fps,
       frames,
+      ffmpegCommand,
     });
     const ffprobe = await verifyEncodedVideo({ command: ffprobeCommand, path: out, frames, fps, width, height });
     if (!ffprobe.matched) throw new Error(`GPU ffprobe verification failed: ${JSON.stringify(ffprobe.checks)}`);

--- a/packages/gpu-export/src/mp4-mux.mjs
+++ b/packages/gpu-export/src/mp4-mux.mjs
@@ -1,6 +1,5 @@
-import { readFile, writeFile } from "node:fs/promises";
-
-import MP4Box from "@webav/mp4box.js";
+import { spawn } from "node:child_process";
+import { stat } from "node:fs/promises";
 
 export function findStartCodes(bytes) {
   const starts = [];
@@ -26,6 +25,11 @@ export function splitAnnexB(bytes) {
   )).filter((nal) => nal.length > 0);
 }
 
+// annexBToAvcc, buildAvcDecoderConfig and buildMp4SampleTiming are no longer on the live mux path:
+// ffmpeg's h264 demuxer reads the elementary stream directly, so nothing here converts to AVCC,
+// derives an avcC, or computes per-sample timing any more. They stay exported because an
+// incremental muxer -- the one shape that could carry each sample's own duration through this
+// path -- would need exactly this logic again, and because they are covered by their own tests.
 export function annexBToAvcc(bytes) {
   const nals = splitAnnexB(bytes);
   const output = Buffer.alloc(nals.reduce((total, nal) => total + 4 + nal.length, 0));
@@ -80,44 +84,90 @@ export function buildMp4SampleTiming({ fps, frames, timescale = 1_000_000 }) {
   };
 }
 
-export async function muxMp4boxDirect({ samples, annexBPath, outputPath, width, height, fps, frames, decoderConfigDescription = null }) {
+// The MP4Box path built the whole MP4 in memory: it read the entire Annex B elementary stream with
+// fs.readFile and then materialised the muxed result through getBuffer(). fs.readFile carries its
+// own 2 GiB cap (kIoMaxLength) that is independent of buffer.constants.MAX_LENGTH, so any export
+// whose elementary stream passed 2 GiB threw ERR_FS_FILE_TOO_LARGE -- "File size (…) is greater
+// than 2 GiB" -- before a single byte of MP4 was written. That is not an edge case at delivery
+// bitrates: a 1280x720 / 30 fps / 1:28:30 export produces a 7.4 GiB stream.
+//
+// ffmpeg streams the same remux with a flat memory profile, so duration no longer bounds what can
+// be muxed. `-c:v copy` keeps it a remux: the encoder's own H.264 bitstream is not touched. The
+// elementary stream carries in-band SPS/PPS, which is what lets the h264 demuxer read it without
+// the avcC we used to hand MP4Box.
+export async function muxEncodedVideo({
+  samples,
+  annexBPath,
+  outputPath,
+  fps,
+  frames,
+  ffmpegCommand,
+  spawnImpl = spawn,
+}) {
   if (samples.length !== frames) throw new Error(`encoded sample count mismatch: expected ${frames}, got ${samples.length}`);
-  const source = await readFile(annexBPath);
-  const avcC = buildAvcDecoderConfig(samples, source, decoderConfigDescription);
-  const file = MP4Box.createFile();
-  const timing = buildMp4SampleTiming({ fps, frames });
-  const track = file.addTrack({
-    timescale: timing.timescale,
-    duration: timing.trackDuration,
-    media_duration: timing.trackDuration,
-    width,
-    height,
-    hdlr: "vide",
-    type: "avc1",
-    avcDecoderConfigRecord: exactArrayBuffer(avcC),
-    default_sample_duration: timing.defaultSampleDuration,
-  });
-  for (const [index, sample] of samples.entries()) {
-    const bytes = source.subarray(sample.offset, sample.offset + sample.length);
-    const timestamp = timing.timestamps[index];
-    file.addSample(track, exactArrayBuffer(annexBToAvcc(bytes).output), {
-      duration: timing.durations[index],
-      dts: timestamp,
-      cts: timestamp,
-      is_sync: sample.type === "key",
-    });
-  }
-  await writeFile(outputPath, Buffer.from(file.getBuffer()));
+  if (!ffmpegCommand) throw new Error("muxEncodedVideo requires an ffmpeg command");
+  const rate = frameRateRational(fps);
+  // stat, never readFile: the whole point of this path is that the elementary stream is handed to
+  // ffmpeg by path and never enters this process's memory.
+  const { size } = await stat(annexBPath);
+  await runFfmpeg(spawnImpl, ffmpegCommand, buildRemuxArguments({ annexBPath, outputPath, rate }));
   return {
-    method: "mp4box-direct",
+    method: "ffmpeg-remux",
     samples: samples.length,
-    bytes: source.length,
+    bytes: size,
     outputPath,
-    timescale: timing.timescale,
-    trackDuration: timing.trackDuration,
+    timescale: rate.timescale,
+    trackDuration: frames * rate.frameTicks,
   };
 }
 
-function exactArrayBuffer(buffer) {
-  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+export function buildRemuxArguments({ annexBPath, outputPath, rate }) {
+  return [
+    "-hide_banner", "-loglevel", "error", "-nostdin", "-y",
+    // The raw h264 demuxer carries no timing of its own, so -framerate is what makes the output CFR
+    // at exactly the declared rate.
+    "-f", "h264",
+    "-framerate", `${rate.num}/${rate.den}`,
+    "-i", annexBPath,
+    "-c:v", "copy",
+    "-an",
+    "-video_track_timescale", String(rate.timescale),
+    // moov before mdat, so the readers that come straight after this (verifyEncodedVideo's
+    // ffprobe, then muxSourceAudio) find the index without scanning gigabytes to reach the tail.
+    "-movflags", "+faststart",
+    outputPath,
+  ];
+}
+
+// Choosing timescale = numerator makes one frame exactly `denominator` ticks, which leaves the
+// rescale from the demuxer's timebase nothing to round: frame i lands on i*denominator ticks for
+// every i. A timescale that is not a multiple of the frame duration loses the same fraction every
+// frame and the error compounds over a long export.
+//
+// Integer rates and the NTSC family are expressed exactly. Any other fractional rate is declared to
+// three decimal places, so the output's nominal rate can differ slightly from the one requested --
+// the ticks stay exact, but 30.123456 fps is muxed as 30.123. verifyEncodedVideo compares the
+// resulting duration against frames/fps and fails the export when that difference matters.
+export function frameRateRational(fps) {
+  if (!Number.isFinite(fps) || fps <= 0) throw new Error("fps must be a positive number");
+  if (Number.isInteger(fps)) return { num: fps, den: 1, timescale: fps, frameTicks: 1 };
+  const ntscNumerator = Math.round(fps * 1001);
+  if (Math.abs(ntscNumerator / 1001 - fps) < 1e-9) {
+    return { num: ntscNumerator, den: 1001, timescale: ntscNumerator, frameTicks: 1001 };
+  }
+  const num = Math.round(fps * 1000);
+  return { num, den: 1000, timescale: num, frameTicks: 1000 };
+}
+
+function runFfmpeg(spawnImpl, command, args) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawnImpl(command, args, { stdio: ["ignore", "ignore", "pipe"] });
+    let stderr = "";
+    child.stderr?.on("data", (chunk) => { stderr += String(chunk); });
+    child.once("error", (error) => rejectPromise(new Error(`ffmpeg remux could not start: ${error.message}`)));
+    child.once("close", (code) => {
+      if (code === 0) resolvePromise();
+      else rejectPromise(new Error(`ffmpeg remux exited ${code}: ${stderr.trim()}`));
+    });
+  });
 }

--- a/packages/gpu-export/src/receipt.mjs
+++ b/packages/gpu-export/src/receipt.mjs
@@ -8,7 +8,10 @@ export function buildGpuReceipt({ tier, launcher = null, run = {}, eligibility =
     provenance: {
       engine: "gpu",
       launcher_tier: tier ?? launcher?.tier ?? null,
-      mux: "mp4box-direct",
+      // The mux result rides on the renderer's checkpoint payload as run.mux (page-runtime.js), so
+      // the receipt reports the method actually used rather than a literal that silently goes stale
+      // the next time this path changes. Runs recorded before the ffmpeg remux carry no mux block.
+      mux: run?.mux?.method ?? "mp4box-direct",
       video_reencode: false,
     },
     gpu: {

--- a/packages/gpu-export/test/mp4-mux.test.mjs
+++ b/packages/gpu-export/test/mp4-mux.test.mjs
@@ -1,10 +1,20 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { annexBToAvcc, buildAvcDecoderConfig, buildMp4SampleTiming, findStartCodes, muxMp4boxDirect, splitAnnexB } from "../src/mp4-mux.mjs";
+import {
+  annexBToAvcc,
+  buildAvcDecoderConfig,
+  buildMp4SampleTiming,
+  buildRemuxArguments,
+  findStartCodes,
+  frameRateRational,
+  muxEncodedVideo,
+  splitAnnexB,
+} from "../src/mp4-mux.mjs";
 
 const bytes = Buffer.from([
   0, 0, 0, 1, 0x67, 0x64, 0x00, 0x28, 0xaa,
@@ -48,21 +58,194 @@ for (const fps of [30, 60, 24]) {
   });
 }
 
-test("mp4box writes one direct sample and finalizes moov", async () => {
+// The regression this whole path exists for. fs.readFile carries its own 2 GiB cap (kIoMaxLength),
+// separate from buffer.constants.MAX_LENGTH, and throws ERR_FS_FILE_TOO_LARGE above it -- so the
+// previous in-memory mux could not write a single byte for any export whose elementary stream
+// passed 2 GiB (a 720p30 1:28:30 export produces 7.4 GiB). Reading the stream at all is the defect;
+// this asserts the module never does, rather than trying to stage a multi-gigabyte fixture in CI.
+test("the elementary stream is never read into this process's memory", async () => {
+  const source = await readFile(new URL("../src/mp4-mux.mjs", import.meta.url), "utf8");
+  // Comments are stripped first so the explanation of the defect cannot satisfy the check.
+  const code = source.replace(/\/\*[\s\S]*?\*\//gu, " ").replace(/(^|\s)\/\/.*$/gmu, "$1");
+  assert.equal(
+    /\breadFile\b/.test(code),
+    false,
+    "mp4-mux must hand the Annex B path to ffmpeg, never buffer it (fs.readFile caps at 2 GiB)",
+  );
+});
+
+test("integer frame rates put one frame on exactly one tick", () => {
+  for (const fps of [24, 25, 30, 50, 60]) {
+    assert.deepEqual(frameRateRational(fps), { num: fps, den: 1, timescale: fps, frameTicks: 1 });
+  }
+});
+
+test("NTSC frame rates stay exact rationals", () => {
+  assert.deepEqual(frameRateRational(30000 / 1001), { num: 30000, den: 1001, timescale: 30000, frameTicks: 1001 });
+  assert.deepEqual(frameRateRational(24000 / 1001), { num: 24000, den: 1001, timescale: 24000, frameTicks: 1001 });
+});
+
+test("other fractional rates keep exact ticks at three declared decimals", () => {
+  assert.deepEqual(frameRateRational(30.5), { num: 30500, den: 1000, timescale: 30500, frameTicks: 1000 });
+});
+
+test("a non-positive frame rate is refused", () => {
+  assert.throws(() => frameRateRational(0), /positive/u);
+  assert.throws(() => frameRateRational(Number.NaN), /positive/u);
+});
+
+test("the remux argv copies the bitstream, drops audio, and writes moov first", () => {
+  const args = buildRemuxArguments({
+    annexBPath: "/tmp/encoded.h264",
+    outputPath: "/tmp/out.mp4",
+    rate: frameRateRational(30),
+  });
+  assert.deepEqual(args, [
+    "-hide_banner", "-loglevel", "error", "-nostdin", "-y",
+    "-f", "h264",
+    "-framerate", "30/1",
+    "-i", "/tmp/encoded.h264",
+    "-c:v", "copy",
+    "-an",
+    "-video_track_timescale", "30",
+    "-movflags", "+faststart",
+    "/tmp/out.mp4",
+  ]);
+});
+
+test("a sample count that disagrees with the frame count is refused before spawning", async () => {
+  let spawned = false;
+  await assert.rejects(
+    muxEncodedVideo({
+      samples: [{ offset: 0, length: 1, type: "key" }],
+      annexBPath: "/tmp/missing.h264",
+      outputPath: "/tmp/out.mp4",
+      fps: 30,
+      frames: 2,
+      ffmpegCommand: "ffmpeg",
+      spawnImpl: () => { spawned = true; throw new Error("must not spawn"); },
+    }),
+    /encoded sample count mismatch: expected 2, got 1/u,
+  );
+  assert.equal(spawned, false);
+});
+
+test("the mux reports the method, the stream size, and exact track timing", async () => {
   const directory = await mkdtemp(join(tmpdir(), "gpu-mp4-mux-"));
   try {
     const annexBPath = join(directory, "encoded.h264");
-    const outputPath = join(directory, "output.mp4");
     await writeFile(annexBPath, bytes);
-    const result = await muxMp4boxDirect({
-      samples: [{ offset: 0, length: bytes.length, type: "key", timestamp: 0, duration: 33_333 }],
-      annexBPath, outputPath, width: 64, height: 64, fps: 30, frames: 1,
+    let seenArgs = null;
+    const result = await muxEncodedVideo({
+      samples: [{ offset: 0, length: bytes.length, type: "key" }],
+      annexBPath,
+      outputPath: join(directory, "out.mp4"),
+      fps: 30,
+      frames: 1,
+      ffmpegCommand: "ffmpeg",
+      spawnImpl: (_command, args) => {
+        seenArgs = args;
+        return fakeChild(0);
+      },
     });
-    const output = await readFile(outputPath);
+    assert.equal(result.method, "ffmpeg-remux");
     assert.equal(result.samples, 1);
-    assert.equal(output.toString("ascii", 4, 8), "ftyp");
-    assert.equal(output.includes(Buffer.from("moov")), true);
+    assert.equal(result.bytes, bytes.length);
+    assert.equal(result.timescale, 30);
+    assert.equal(result.trackDuration, 1);
+    assert.ok(seenArgs.includes(annexBPath));
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+test("a non-zero ffmpeg exit surfaces its stderr", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "gpu-mp4-mux-"));
+  try {
+    const annexBPath = join(directory, "encoded.h264");
+    await writeFile(annexBPath, bytes);
+    await assert.rejects(
+      muxEncodedVideo({
+        samples: [{ offset: 0, length: bytes.length, type: "key" }],
+        annexBPath,
+        outputPath: join(directory, "out.mp4"),
+        fps: 30,
+        frames: 1,
+        ffmpegCommand: "ffmpeg",
+        spawnImpl: () => fakeChild(1, "Invalid data found when processing input"),
+      }),
+      /ffmpeg remux exited 1: Invalid data found when processing input/u,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("real ffmpeg produces a faststart mp4 whose moov precedes mdat", { skip: await ffmpegSkipReason() }, async () => {
+  const ffmpegCommand = resolveTestFfmpeg();
+  const directory = await mkdtemp(join(tmpdir(), "gpu-mp4-mux-real-"));
+  try {
+    const annexBPath = join(directory, "encoded.h264");
+    const outputPath = join(directory, "out.mp4");
+    await run(ffmpegCommand, [
+      "-hide_banner", "-loglevel", "error", "-y",
+      "-f", "lavfi", "-i", "testsrc=size=64x64:rate=30",
+      "-frames:v", "6", "-c:v", "libx264", "-pix_fmt", "yuv420p",
+      "-f", "h264", annexBPath,
+    ]);
+    const result = await muxEncodedVideo({
+      samples: Array.from({ length: 6 }, () => ({ type: "key" })),
+      annexBPath,
+      outputPath,
+      fps: 30,
+      frames: 6,
+      ffmpegCommand,
+    });
+    const output = await readFile(outputPath);
+    assert.equal(result.method, "ffmpeg-remux");
+    assert.equal(output.toString("ascii", 4, 8), "ftyp");
+    const moov = output.indexOf(Buffer.from("moov"));
+    const mdat = output.indexOf(Buffer.from("mdat"));
+    assert.ok(moov > 0, "muxed file has no moov box");
+    assert.ok(mdat > 0, "muxed file has no mdat box");
+    assert.ok(moov < mdat, `faststart failed: moov at ${moov} is not before mdat at ${mdat}`);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function fakeChild(code, stderr = "") {
+  const listeners = new Map();
+  const child = {
+    stderr: { on: (event, handler) => { if (event === "data" && stderr) handler(Buffer.from(stderr)); } },
+    once: (event, handler) => { listeners.set(event, handler); return child; },
+  };
+  queueMicrotask(() => listeners.get("close")?.(code, null));
+  return child;
+}
+
+function resolveTestFfmpeg() {
+  return process.env.FFMPEG ?? process.env.AKARI_FFMPEG_BIN ?? "ffmpeg";
+}
+
+function run(command, args) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(command, args, { stdio: ["ignore", "ignore", "pipe"] });
+    let stderr = "";
+    child.stderr?.on("data", (chunk) => { stderr += String(chunk); });
+    child.once("error", rejectPromise);
+    child.once("close", (code) => (code === 0 ? resolvePromise() : rejectPromise(new Error(stderr.trim()))));
+  });
+}
+
+// Vendor binaries are not present in every checkout, and libx264 is not guaranteed even when ffmpeg
+// is, so the end-to-end case reports why it stood down instead of failing the suite.
+async function ffmpegSkipReason() {
+  try {
+    await run(resolveTestFfmpeg(), ["-hide_banner", "-loglevel", "error", "-f", "lavfi",
+      "-i", "testsrc=size=16x16:rate=30", "-frames:v", "1", "-c:v", "libx264", "-f", "null", "-"]);
+    return false;
+  } catch {
+    return "ffmpeg with libx264 is unavailable in this checkout";
+  }
+}

--- a/packages/gpu-export/test/receipt.test.mjs
+++ b/packages/gpu-export/test/receipt.test.mjs
@@ -3,6 +3,16 @@ import test from "node:test";
 
 import { buildGpuReceipt } from "../src/receipt.mjs";
 
+test("GPU receipt reports the mux method the run actually used", () => {
+  const remuxed = buildGpuReceipt({ tier: 2, run: { mux: { method: "ffmpeg-remux", samples: 3 } } });
+  assert.equal(remuxed.provenance.mux, "ffmpeg-remux");
+});
+
+test("a run recorded before the ffmpeg remux keeps reading as mp4box-direct", () => {
+  assert.equal(buildGpuReceipt({ tier: 2, run: { status: "completed" } }).provenance.mux, "mp4box-direct");
+  assert.equal(buildGpuReceipt({ tier: 2 }).provenance.mux, "mp4box-direct");
+});
+
 test("GPU receipt records direct mux, no re-encode, and every eligibility row", () => {
   const entries = [
     { kind: "overlay", id: "a", classification: "same", reason: "static", conditions: [] },


### PR DESCRIPTION
## これが直すもの

長尺の GPU 書き出しが **MP4 を 1 バイトも書かずに** 失敗する。

`muxMp4boxDirect` は Annex B の素ストリーム全体を `fs.readFile` で 1 つの Buffer に読み、MP4Box の `getBuffer()` で多重化結果をもう一度実体化していた。`fs.readFile` には `buffer.constants.MAX_LENGTH` とは別に自前の 2 GiB 上限（`kIoMaxLength`）がある。Node 22.22.1 で実測:

```
size=3221225472
readFile THREW: ERR_FS_FILE_TOO_LARGE -- File size (3221225472) is greater than 2 GiB
```

配信ビットレートではこれは例外的な尺ではない。1280x720 / 30fps / 1:28:30 の書き出しで素ストリームは **7.4 GiB** に達する。エンコードを全部終えたあと、mux の入口で落ちる。

## 変更

**`mp4-mux.mjs`** — `muxMp4boxDirect` → `muxEncodedVideo`。素ストリームは読まず、パスのまま ffmpeg へ渡す。

```
-f h264 -framerate <num>/<den> -i <annexb> -c:v copy -an
  -video_track_timescale <ts> -movflags +faststart <out>
```

- `-c:v copy` なので**エンコーダが出した H.264 ビットストリームには触れない**。remux のまま
- 素ストリームは in-band SPS/PPS を持つため、MP4Box に渡していた avcC を作る必要がない
- 返り値の `bytes` は `stat` 由来

**タイムスケール** — `timescale = 分子` とし、1 コマ = 分母ティックの整数にする。整数 fps と NTSC 系は厳密。それ以外は宣言レートを小数 3 桁へ丸めるため公称 fps がわずかにずれるが、ティック自体は厳密で、ずれが問題になる場合は既存の `verifyEncodedVideo` が尺で落とす。

**`+faststart`** — 直後に走る `verifyEncodedVideo` の ffprobe と `muxSourceAudio` が、索引を求めて末尾まで走査しなくて済む。

**`electron-main.mjs`** — `ffprobeCommand` と同じ形で `ffmpegCommand` を env から解決して渡す。

**`receipt.mjs`** — mux 方式をリテラルではなく `run.mux.method`（renderer の checkpoint 経由）から取る。方式が変わったのにレシートが旧名を記録し続けるのを防ぐ。旧 run には `mux` ブロックが無いので従来値へフォールバックする。

**`@webav/mp4box.js` の import を落とした。** `gpu-export` の `package.json` はこれを依存に宣言しておらず、`frame-engine` 経由で解決していた。

`annexBToAvcc` / `buildAvcDecoderConfig` / `buildMp4SampleTiming` は live な mux 経路から外れたが、1 サンプルごとの尺を運べる唯一の形である逐次 mux を将来入れるときに再び必要になるため、テストごと残した。

## テスト

素ストリームを読まない不変条件は、**コメントを除いたモジュール本文に `readFile` が現れないこと**で固定した。CI に数 GiB の fixture を置かずに再発を捕まえるため。

実 ffmpeg 経路は **moov が mdat より前にある**ことまで確認する（faststart の実証）。libx264 が無い checkout では理由つきで skip する。

ほかに argv 全体の一致、`frameRateRational` の 3 系統（整数 / NTSC / その他小数）、コマ数不一致で spawn 前に落ちること、ffmpeg の非ゼロ終了が stderr を載せて上がること。

### この checkout での結果

`node_modules` 未導入の環境で `packages/gpu-export` のスイートを比較した。

| | main (`ec30f386`) | このブランチ |
|---|---|---|
| tests | 87 | 111 |
| pass | 80 | 105 |
| fail | 7 | 6 |

main 側の失敗 7 件のうち 2 件は**ファイルごと読み込めていない**もの（`mp4-mux.test.mjs` / `page-builder.test.mjs`）。どちらも未宣言の `@webav/mp4box.js` に到達して落ちていた。この PR で import が消えたため両方とも読み込めるようになり、走るテストが 87 → 111 に増えている。

新たに増えた失敗はない。両者に共通して残る 5 件は既存。加えて `page-builder.test.mjs` が読めるようになったことで、その中の 1 件が表に出た:

```
- expected: '/tmp/export/raw/frame-12.rgba'
+ actual:   '\tmp\export\raw\frame-12.rgba'
```

これは `join()` の区切り文字を直書きで比較している **Windows 限定の既存テスト不備**で、この変更とは無関係（Linux CI では通る）。今まで隠れていただけなので、別途直すのが筋だと思う。

## 実機

Windows / 1280x720 30fps / **159,297 コマ（1:28:30）** を GPU 経路で完走。

- 出力 **7.53 GB**、`PASS` / `phase: verified`
- ffprobe の frames / duration / dimensions / codec **すべて一致**
- 尺は予測 5309.907s に対し実測 **5309.900s**
- `timescale: 30` / `trackDuration: 159297` = **1 コマ 1 ティック**
- receipt の `mux` が `ffmpeg-remux` になることを実 `run.json` で確認

同じ素材は変更前の main では `ERR_FS_FILE_TOO_LARGE` で失敗する。

## 入れなかったもの

同じ調査で手元に溜まっていた変更のうち、以下は**意図的に外した**。

- **cut 段への `+faststart`** — v2 の cut 段は `bde30947` で音声専用になっており、GPU ページは `edit.sources` を直接読む。cut.mp4 を range 読みする前提そのものが main には無い
- **frame-engine の Range 読み** — `#120i`（`c4e6fc8b` / `7fe57642`）が同じ領域を作り直している最中
- **`ELECTRON_RUN_AS_NODE` 除去 / cut ごとの入力側シーク / tail-pad 廃止 / slot params** — いずれも main にすでにあり、上流の実装の方が良い（プリロール・入力数上限・本物の `slot-params.js` を inline）
