### PR TITLE
[修正] 長尺のメトリクス集計でスタックが溢れる — 約 69 分を超える書き出しが完走後に捨てられる

### DIFF
--- a/packages/frame-engine/src/metrics/collector.ts
+++ b/packages/frame-engine/src/metrics/collector.ts
@@ -35,6 +35,19 @@ const STAGES: readonly FrameMetricStage[] = [
   'ffmpegClose'
 ];
 
+// Math.max(...values) passes one argument per sample and overflows the stack past roughly 125k
+// arguments (measured on Node 22). record() appends once per frame per stage, so any export longer
+// than about 69 minutes at 30fps crosses that line -- and toJSON() runs after every frame is
+// already encoded, so the throw would discard a finished export at the last step. A loop has no
+// such ceiling. percentile's [...values] is an array spread, which is not argument-bound.
+function maxOf(values: readonly number[]): number {
+  let max = -Infinity;
+  for (const value of values) {
+    if (value > max) max = value;
+  }
+  return max;
+}
+
 function percentile(values: readonly number[], value: number): number | null {
   if (values.length === 0) return null;
   const sorted = [...values].sort((left, right) => left - right);
@@ -72,7 +85,7 @@ export class FrameMetrics implements FrameMetricsRecorder {
         count: values.length,
         p50Ms: percentile(values, 50),
         p95Ms: percentile(values, 95),
-        maxMs: values.length > 0 ? Math.max(...values) : null
+        maxMs: values.length > 0 ? maxOf(values) : null
       }];
       })),
       uploadPath: this.uploadPath,

--- a/packages/frame-engine/test/metrics.test.mjs
+++ b/packages/frame-engine/test/metrics.test.mjs
@@ -29,3 +29,18 @@ test('FrameMetrics emits every detailed p50/p95 stage', () => {
   assert.equal(routed.uploadPath, 'copyTo');
   assert.deepEqual(routed.uploadPathCounts, { direct: 1, copyTo: 1 });
 });
+
+// toJSON() runs after every frame is already encoded, so a throw here discards a finished export.
+// 130k samples is one stage of a ~72 minute 30fps render and sits past the ~125k argument ceiling
+// that Math.max(...values) hit on Node 22.
+test('a long render summarizes without overflowing the stack', () => {
+  const metrics = new FrameMetrics();
+  const samples = 130_000;
+  for (let index = 0; index < samples; index += 1) {
+    metrics.record('decode', index === 4242 ? 999 : 1);
+  }
+  const output = metrics.toJSON();
+  assert.equal(output.decode.count, samples);
+  assert.equal(output.decode.maxMs, 999);
+  assert.equal(output.decode.p50Ms, 1);
+});


### PR DESCRIPTION
## これが直すもの

**エンコードを全部終えた書き出しが、最後の一歩で捨てられる。**

`FrameMetrics.toJSON()` の `maxMs` が `Math.max(...values)` で、サンプル 1 個につき引数を 1 個渡していた。`record()` は 1 コマ 1 ステージにつき 1 回積むので、サンプル数はそのまま総コマ数になる。

Node 22.22.1 での実測:

```
1000   -> ok
65536  -> ok
125000 -> RangeError: Maximum call stack size exceeded
159297 -> RangeError: Maximum call stack size exceeded
```

30fps なら **約 69 分**でこの線を越える。そして `toJSON()` が走るのは全コマのエンコードが終わったあとなので、落ちる場所は「あとは書くだけ」の地点。

実データ。1280x720 / 30fps / 1:28:30 の書き出しが残した `gpu-run.json`:

```json
"decode": { "count": 159297, "p50Ms": 0.2, "p95Ms": 18.1, "maxMs": 51955.4 },
"tick":   { "count": 159297, "p50Ms": 0.2, "p95Ms": 18.1, "maxMs": 4992.7 },
"upload": { "count": 159297, "p50Ms": 1,   "p95Ms": 1.8,  "maxMs": 56.5 },
"shader": { "count": 159297, "p50Ms": 0,   "p95Ms": 0.1,  "maxMs": 5.4 }
```

4 ステージがそれぞれ 159,297 サンプル。上の閾値の 1.27 倍。

## 変更

`Math.max(...values)` を `maxOf()` のループへ置換した。引数上限が無いので長さに天井がない。

`percentile` の `[...values]` は**配列**スプレッドで引数上限とは無関係なため、触っていない。

## テスト

`metrics.test.mjs` に 130,000 サンプル（約 72 分相当・上記の閾値より上）のケースを足し、`toJSON()` が最大値と p50 を返すことを固定した。

### 実行できていないこと

このパッケージのテストは `../dist/index.js` を読むためビルドが要る。手元の checkout は `node_modules` が無くビルドできないので、**このスイート自体は走らせていない**。

代わりに、置換の等価性を同じ Node で直接確かめた:

| 確認 | 結果 |
|---|---|
| 1 / 2 / 1,000 / 65,536 サンプルで `Math.max` と一致 | PASS |
| 159,297 サンプルで `Math.max` が throw | PASS |
| 159,297 サンプルで `maxOf` が 51,955.4 を返す | PASS |
| 単一要素 / 全同値 / 全ゼロ（`-Infinity` に落ちない） | PASS |

CI でビルド込みの実行をお願いしたい。

## 補足

`7fe57642`（#120i r1）が直した「長尺のスタック溢れ」は Range 経路の別の箇所で、ここは未修正のまま残っていた。
