### PR TITLE
[修正] スキルから packages/ が引けない — 配布版・同梱版どちらでも解決する探索規則 + GPL 資産の再配布禁止ガード + RVM の行き止まり撤去

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '26.3.0'
+      # 同じ required の配布ゲートへ相乗りし、RVM コード・重みの混入を最短で止める。
+      # Node 組み込みのみで追加 install は不要なため、依存 staging より先に実行する。
+      - name: check-no-gpl-redistribution
+        run: node scripts/release/check-no-gpl-redistribution.mjs
       # v0.1.25 の同梱漏れ（packages/gpu-export / skills/analyze-footage/bin/person-matte / @webav/mp4box.js）は
       # モノレポのテストでは見えず、実ビルドのパッケージ版でだけ ERR_MODULE_NOT_FOUND になった。
       # release.yml と同じ手順で同梱 npm 入口を staging し、extraResources どおりの模擬 Resources から

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -47,9 +47,10 @@ Supply differs by platform (no official macOS binary distribution exists):
 
 ## Robust Video Matting (RVM)
 
-This product downloads and uses the official ONNX models from
-PeterL1n/RobustVideoMatting as a separate inference asset. Robust Video
-Matting is MIT licensed. Source and license:
+Robust Video Matting is GPL-3.0 licensed. This product distributes neither
+RVM code nor model weights. At the user's direction, model weights are
+downloaded from upstream onto the user's machine as an opt-in addition.
+Source and license:
 https://github.com/PeterL1n/RobustVideoMatting
 
 Model URLs and sha256 checksums are pinned in

--- a/apps/shell/package.json
+++ b/apps/shell/package.json
@@ -187,7 +187,8 @@
         "from": "../../skills/analyze-footage/bin/person-matte",
         "to": "skills/analyze-footage/bin/person-matte",
         "filter": [
-          "*.mjs"
+          "*.mjs",
+          "person-matte-helper.swift"
         ]
       },
       {
@@ -244,6 +245,14 @@
         ]
       },
       {
+        "from": "../../packages/chat-bridge",
+        "to": "packages/chat-bridge",
+        "filter": [
+          "package.json",
+          "src/**/*"
+        ]
+      },
+      {
         "from": "resources/cli-node-modules",
         "to": "packages/node_modules"
       },
@@ -277,8 +286,10 @@
         "to": "packages/schemas",
         "filter": [
           "captions.schema.json",
+          "edit.schema.json",
           "interpretation.schema.json",
           "bin/validate-asset.mjs",
+          "bin/validate-edit.mjs",
           "bin/validate-interpretation.mjs",
           "bin/validate-word-book.mjs",
           "word-book.schema.json"

--- a/packages/matte-rvm/README.md
+++ b/packages/matte-rvm/README.md
@@ -1,0 +1,5 @@
+# Robust Video Matting integration policy
+Robust Video Matting (RVM) upstream is licensed under GPL-3.0, while this product is distributed under MIT.
+The product therefore bundles neither RVM code nor model weights; an opt-in command downloads weights from upstream onto the user's machine.
+The upstream URLs and sha256 checksums are pinned in `src/model-manifest.mjs`.
+`scripts/release/check-no-gpl-redistribution.mjs` enforces this distribution boundary mechanically.

--- a/packages/matte-rvm/bin/rvm-helper.mjs
+++ b/packages/matte-rvm/bin/rvm-helper.mjs
@@ -8,7 +8,18 @@ import path from "node:path";
 import { once } from "node:events";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
-import ort from "onnxruntime-node";
+
+const RUNTIME_UNAVAILABLE_REASON =
+  "RVM の実行環境が入っていないため、この品質では人物マットを生成できません。直すには cd packages/matte-rvm && npm install を実行してください";
+
+async function loadRuntime(importRuntime = (specifier) => import(specifier)) {
+  try {
+    const loaded = await importRuntime("onnxruntime-node");
+    return loaded.default ?? loaded;
+  } catch {
+    return null;
+  }
+}
 
 function parseArguments(argv) {
   const options = {
@@ -80,7 +91,7 @@ async function writeFrame(frame) {
   if (!process.stdout.write(frame)) await once(process.stdout, "drain");
 }
 
-async function run(options) {
+async function run(options, ort) {
   const pixels = options.width * options.height;
   const frameBytes = pixels * 4;
   const ratio = options.downsampleRatio ?? recommendedRatio(options);
@@ -183,8 +194,13 @@ function isMainModule() {
 }
 
 if (isMainModule()) {
-  run(parseArguments(process.argv.slice(2))).catch((error) => {
-    process.stderr.write(`${JSON.stringify({ error: String(error?.message ?? error) })}\n`);
-    process.exitCode = 1;
-  });
+  const ort = await loadRuntime();
+  if (!ort) {
+    process.stdout.write(`${JSON.stringify({ ok: false, reason: RUNTIME_UNAVAILABLE_REASON })}\n`);
+  } else {
+    run(parseArguments(process.argv.slice(2)), ort).catch((error) => {
+      process.stderr.write(`${JSON.stringify({ error: String(error?.message ?? error) })}\n`);
+      process.exitCode = 1;
+    });
+  }
 }

--- a/packages/matte-rvm/package.json
+++ b/packages/matte-rvm/package.json
@@ -9,11 +9,11 @@
     ".": "./src/index.mjs"
   },
   "scripts": {
-    "postinstall": "node scripts/fetch-models.mjs",
+    "fetch:models": "node scripts/fetch-models.mjs",
     "fetch:resnet50": "node scripts/fetch-models.mjs --model resnet50",
     "test": "node --test \"test/*.test.mjs\""
   },
-  "dependencies": {
+  "optionalDependencies": {
     "onnxruntime-node": "1.29.0"
   },
   "engines": {

--- a/packages/matte-rvm/src/index.mjs
+++ b/packages/matte-rvm/src/index.mjs
@@ -1,9 +1,33 @@
 import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 
 import { MODEL_MANIFEST, VENDOR_ROOT, modelPath } from "./model-manifest.mjs";
 
 export const DEFAULT_RVM_MODEL = "mobilenetv3";
+export const RVM_RUNTIME_UNAVAILABLE_REASON =
+  "RVM の実行環境が入っていないため、この品質では人物マットを生成できません";
+export const RVM_RUNTIME_INSTALL_HINT = "cd packages/matte-rvm && npm install";
+
+const require = createRequire(import.meta.url);
+
+/** Resolve the optional RVM runtime without loading its native module. */
+export function resolveRvmRuntime({ resolveRuntime = require.resolve.bind(require) } = {}) {
+  try {
+    resolveRuntime("onnxruntime-node");
+    return {
+      available: true,
+      reason: null,
+      installHint: RVM_RUNTIME_INSTALL_HINT,
+    };
+  } catch {
+    return {
+      available: false,
+      reason: RVM_RUNTIME_UNAVAILABLE_REASON,
+      installHint: RVM_RUNTIME_INSTALL_HINT,
+    };
+  }
+}
 
 /** Resolve a managed RVM model without making model absence exceptional. */
 export function resolveRvmModel(model = DEFAULT_RVM_MODEL, { env = process.env } = {}) {

--- a/packages/matte-rvm/test/manifest.test.mjs
+++ b/packages/matte-rvm/test/manifest.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { resolveRvmRuntime } from "../src/index.mjs";
 import { MODEL_MANIFEST } from "../src/model-manifest.mjs";
 
 const releaseRoot =
@@ -19,4 +20,26 @@ test("model manifest pins the official v1.0.0 URLs and measured sha256 values", 
       sha256: "25db300fcb6ee27f941a1b52c97856e8d1f13c7f35817f81a612f89af0e8a85c",
     },
   });
+});
+
+test("RVM runtime resolution is non-exceptional and does not load the native module", () => {
+  const calls = [];
+  assert.deepEqual(resolveRvmRuntime({
+    resolveRuntime: (specifier) => {
+      calls.push(specifier);
+      return "/mock/runtime.js";
+    },
+  }), {
+    available: true,
+    reason: null,
+    installHint: "cd packages/matte-rvm && npm install",
+  });
+  assert.deepEqual(calls, ["onnxruntime-node"]);
+
+  const missing = resolveRvmRuntime({
+    resolveRuntime: () => { throw new Error("not found"); },
+  });
+  assert.equal(missing.available, false);
+  assert.match(missing.reason, /RVM の実行環境が入っていない/u);
+  assert.equal(missing.installHint, "cd packages/matte-rvm && npm install");
 });

--- a/packages/matte-rvm/test/person-matte-platform.test.mjs
+++ b/packages/matte-rvm/test/person-matte-platform.test.mjs
@@ -14,6 +14,11 @@ const installedModel = {
   missing: false,
   fetchHint: "cd packages/matte-rvm && node scripts/fetch-models.mjs",
 };
+const installedRuntime = {
+  available: true,
+  reason: null,
+  installHint: "cd packages/matte-rvm && npm install",
+};
 
 function successfulMediaProbe(command, args) {
   if (command === "/mock/ffmpeg" && args.includes("-encoders")) {
@@ -28,6 +33,7 @@ test("win32 maps every quality to RVM mobilenetv3 without building Vision", () =
     const prepared = prepareExecution(parseArguments(["--quality", quality]), {
       platform: "win32",
       resolveModel: () => installedModel,
+      resolveRuntime: () => installedRuntime,
       buildVisionHelper: () => {
         visionBuilds += 1;
         return null;
@@ -52,6 +58,7 @@ test("win32 availability probes only media tools and never swiftc", () => {
     resolveFfmpegBin: () => "/mock/ffmpeg",
     resolveFfprobeBin: () => "/mock/ffprobe",
     resolveModel: () => installedModel,
+    resolveRuntime: () => installedRuntime,
   });
   assert.deepEqual(availability, { available: true });
   assert.deepEqual(calls, [
@@ -73,6 +80,7 @@ test("win32 availability requires the managed mobilenetv3 model", () => {
     resolveFfmpegBin: () => "/mock/ffmpeg",
     resolveFfprobeBin: () => "/mock/ffprobe",
     resolveModel: () => missingModel,
+    resolveRuntime: () => installedRuntime,
   });
   assert.equal(result.available, false);
   assert.match(result.reason, /FETCH_MNV3_MODEL/);
@@ -103,12 +111,48 @@ test("availability converts a media-bin resolution error to the unavailable shap
   });
 });
 
+test("win32 availability reports a missing RVM runtime with one install command", () => {
+  const result = checkAvailability({
+    platform: "win32",
+    runSync: successfulMediaProbe,
+    resolveFfmpegBin: () => "/mock/ffmpeg",
+    resolveFfprobeBin: () => "/mock/ffprobe",
+    resolveModel: () => installedModel,
+    resolveRuntime: () => ({
+      available: false,
+      reason: "RVM の実行環境が入っていないため、この品質では人物マットを生成できません",
+      installHint: "cd packages/matte-rvm && npm install",
+    }),
+  });
+  assert.equal(result.available, false);
+  assert.match(result.reason, /RVM の実行環境が入っていない/u);
+  assert.match(result.reason, /cd packages\/matte-rvm && npm install/u);
+  assert.doesNotMatch(result.reason, /ERR_MODULE_NOT_FOUND|onnxruntime-node|optionalDependencies/u);
+});
+
+test("prepareExecution stops a missing RVM runtime before returning a spawnable plan", () => {
+  assert.throws(
+    () => prepareExecution(parseArguments(["--quality", "best"]), {
+      platform: "darwin",
+      resolveModel: () => installedModel,
+      resolveRuntime: () => ({
+        available: false,
+        reason: "RVM の実行環境が入っていないため、この品質では人物マットを生成できません",
+        installHint: "cd packages/matte-rvm && npm install",
+      }),
+      buildVisionHelper: () => assert.fail("RVM must not build Vision"),
+    }),
+    /RVM の実行環境が入っていない.*cd packages\/matte-rvm && npm install/u,
+  );
+});
+
 test("darwin keeps Vision for non-best, RVM for best, and does not require the RVM model", () => {
   let visionBuilds = 0;
   for (const quality of QUALITIES) {
     const prepared = prepareExecution(parseArguments(["--quality", quality]), {
       platform: "darwin",
       resolveModel: () => installedModel,
+      resolveRuntime: () => installedRuntime,
       buildVisionHelper: () => {
         visionBuilds += 1;
         return null;

--- a/packages/matte-rvm/test/rvm-helper.test.mjs
+++ b/packages/matte-rvm/test/rvm-helper.test.mjs
@@ -1,11 +1,30 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFile, rm } from "node:fs/promises";
+import { copyFile, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import { resolveRvmModel } from "../src/index.mjs";
+
+test("rvm-helper returns one plain JSON line when its runtime cannot be resolved", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "akari-rvm-helper-no-runtime-"));
+  const helper = path.join(directory, "rvm-helper.mjs");
+  try {
+    await copyFile(path.resolve(import.meta.dirname, "../bin/rvm-helper.mjs"), helper);
+    const result = spawnSync(process.execPath, [helper], { cwd: directory, encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stderr, "");
+    assert.equal(result.stdout.trimEnd().split("\n").length, 1);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, false);
+    assert.match(output.reason, /RVM の実行環境が入っていない/u);
+    assert.match(output.reason, /cd packages\/matte-rvm && npm install/u);
+    assert.doesNotMatch(output.reason, /ERR_MODULE_NOT_FOUND|onnxruntime-node|optionalDependencies/u);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
 
 test("rvm-helper uses the official automatic downsample ratios", async (t) => {
   const resolved = resolveRvmModel("mobilenetv3");

--- a/scripts/release/check-no-gpl-redistribution.mjs
+++ b/scripts/release/check-no-gpl-redistribution.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+// GPL / 制限付き資産の再配布ガード — MIT 配布物への混入を CI で機械検出する。
+//
+// なぜ要るか: RVM upstream (PeterL1n/RobustVideoMatting) は GPL-3.0、本プロダクトは MIT で配布するため、
+// RVM のコードや重みは同梱した瞬間に再配布になる。2026-08-07 の調査では配布対象から除外していたが、
+// その判断が後続作業へ引き継がれず NOTICE に MIT との誤記が入った。人の記憶ではなく配布ゲートで守る。
+//
+// やること:
+//   1. Electron shell の build.files / extraFiles / extraResources が制限対象を取り込まないことを検査
+//   2. 制限対象配下のモデル重みが git 追跡されていないことを検査
+//   3. npm prepack の VENDOR_SOURCES / package.json#files / capability sources を検査
+//
+// 使い方:
+//   node scripts/release/check-no-gpl-redistribution.mjs
+//     [--repo-root <path>] [--shell-package <path>] [--tracked-files <1行1パス>]
+//     [--prepack <path>]
+// 終了コード: 違反 0 なら 0、1 件以上または入力を安全に検査できなければ 1。
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, isAbsolute, posix, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// 配布物に matte-rvm のパス文字列があるだけでは違反にしない。akari-launcher の capability discovery は
+// package.json / README*.md を無条件に収集するが、これらは我々が書いた MIT の能書きメタデータであり、
+// RVM のコードも重みも含まないためである。許可するものをここで狭く列挙し、それ以外は拒否する。
+export const RESTRICTED_ASSETS = [
+  {
+    id: 'rvm',
+    license: 'GPL-3.0',
+    reason: 'upstream PeterL1n/RobustVideoMatting is GPL-3.0; this product ships under MIT',
+    paths: ['packages/matte-rvm'],
+    distributableMetadata: [
+      'packages/matte-rvm/package.json',
+      /^packages\/matte-rvm\/README[^/]*\.md$/u,
+    ],
+  },
+];
+
+const WEIGHT_EXTENSIONS = new Set([
+  '.bin', '.ckpt', '.h5', '.onnx', '.pb', '.pt', '.pth', '.safetensors', '.tflite', '.weights',
+]);
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const DEFAULT_REPO_ROOT = resolve(dirname(SCRIPT_PATH), '..', '..');
+
+export function checkShellPackage(shellPackage) {
+  const violations = [];
+  for (const field of ['extraResources', 'files', 'extraFiles']) {
+    const entries = shellPackage?.build?.[field];
+    if (entries === undefined) continue;
+    if (!Array.isArray(entries)) {
+      throw new Error(`apps/shell/package.json build.${field} must be an array`);
+    }
+    entries.forEach((entry, index) => {
+      const label = `apps/shell/package.json build.${field}[${index}]`;
+      if (typeof entry === 'string') {
+        if (entry.startsWith('!')) return;
+        const normalized = normalizePattern(entry, 'apps/shell');
+        for (const asset of RESTRICTED_ASSETS) {
+          if (patternMayIncludeAsset(normalized, asset)) {
+            violations.push(violation(label, normalized, asset, 'MIT 配布物へ同梱できない'));
+          }
+        }
+        return;
+      }
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry) || typeof entry.from !== 'string') {
+        throw new Error(`${label} must be a string or an object with a string from`);
+      }
+
+      const from = normalizePattern(entry.from, 'apps/shell');
+      const filters = entry.filter === undefined ? null : entry.filter;
+      if (filters !== null && (!Array.isArray(filters) || filters.some((item) => typeof item !== 'string'))) {
+        throw new Error(`${label}.filter must be an array of strings`);
+      }
+      for (const asset of RESTRICTED_ASSETS) {
+        if (sourceMayIncludeAsset(from, filters, asset)) {
+          violations.push(violation(label, from, asset, 'source/filter が制限対象を配布物へ取り込む'));
+          continue;
+        }
+        if (typeof entry.to === 'string') {
+          const destination = normalizePattern(entry.to, '');
+          if (containsRestrictedLiteral(destination, asset)) {
+            violations.push(violation(label, destination, asset, '配布先が制限対象パスを指している'));
+          }
+        } else if (entry.to !== undefined) {
+          throw new Error(`${label}.to must be a string`);
+        }
+      }
+    });
+  }
+  return violations;
+}
+
+export function checkTrackedFiles(trackedFiles) {
+  if (!Array.isArray(trackedFiles) || trackedFiles.some((item) => typeof item !== 'string')) {
+    throw new Error('trackedFiles must be an array of strings');
+  }
+  const violations = [];
+  for (const rawPath of trackedFiles) {
+    const file = normalizeRepoPath(rawPath);
+    const extension = posix.extname(file).toLowerCase();
+    if (!WEIGHT_EXTENSIONS.has(extension)) continue;
+    for (const asset of RESTRICTED_ASSETS) {
+      if (asset.paths.some((root) => isSameOrDescendant(file, root))) {
+        violations.push(violation('git ls-files', file, asset, `モデル重み ${extension} が git 追跡下にある`));
+      }
+    }
+  }
+  return violations;
+}
+
+export function checkNpmDistribution({ prepackSource, packageManifests, capabilitySources }) {
+  if (typeof prepackSource !== 'string') throw new Error('prepackSource must be a string');
+  if (!Array.isArray(packageManifests)) throw new Error('packageManifests must be an array');
+  if (!Array.isArray(capabilitySources) || capabilitySources.some((item) => typeof item !== 'string')) {
+    throw new Error('capabilitySources must be an array of strings');
+  }
+
+  const violations = [];
+  for (const source of new Set(extractVendorSources(prepackSource))) {
+    const normalized = normalizeRepoPath(source);
+    for (const asset of RESTRICTED_ASSETS) {
+      if (patternMayIncludeAsset(normalized, asset) && !isAllowedMetadata(asset, normalized)) {
+        violations.push(violation('packages/akari-launcher/scripts/prepack.mjs VENDOR_SOURCES', normalized, asset,
+          'npm vendor へコードまたは重みをコピーする'));
+      }
+    }
+  }
+
+  for (const entry of packageManifests) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)
+      || typeof entry.path !== 'string' || !entry.manifest || typeof entry.manifest !== 'object'
+      || Array.isArray(entry.manifest)) {
+      throw new Error('each packageManifests entry must be { path, manifest }');
+    }
+    const files = entry.manifest.files;
+    if (files === undefined) continue;
+    if (!Array.isArray(files) || files.some((item) => typeof item !== 'string')) {
+      throw new Error(`${entry.path} files must be an array of strings`);
+    }
+    const manifestDir = posix.dirname(normalizeRepoPath(entry.path));
+    files.forEach((file, index) => {
+      if (file.startsWith('!')) return;
+      const normalized = normalizePattern(file, manifestDir === '.' ? '' : manifestDir);
+      for (const asset of RESTRICTED_ASSETS) {
+        if (patternMayIncludeAsset(normalized, asset) && !isAllowedMetadata(asset, normalized)) {
+          violations.push(violation(`${entry.path} files[${index}]`, normalized, asset,
+            'npm package.json#files がコードまたは重みを含める'));
+        }
+      }
+    });
+  }
+
+  for (const source of capabilitySources) {
+    const normalized = normalizeRepoPath(source);
+    for (const asset of RESTRICTED_ASSETS) {
+      if (containsRestrictedLiteral(normalized, asset) && !isAllowedMetadata(asset, normalized)) {
+        violations.push(violation('akari-launcher capability source', normalized, asset,
+          '許可された能書きメタデータ以外を npm vendor へコピーする'));
+      }
+    }
+  }
+  return violations;
+}
+
+function sourceMayIncludeAsset(from, filters, asset) {
+  if (filters === null || filters.length === 0) return patternMayIncludeAsset(from, asset);
+  const positives = filters.filter((item) => !item.startsWith('!'));
+  const candidates = positives.length > 0 ? positives : ['**/*'];
+  const included = candidates.some((filter) => patternMayIncludeAsset(normalizePattern(filter, from), asset));
+  if (!included) return false;
+  const exclusions = filters.filter((item) => item.startsWith('!'))
+    .map((item) => normalizePattern(item.slice(1), from));
+  return !asset.paths.every((root) => exclusions.some((pattern) => patternCoversRoot(pattern, root)));
+}
+
+function patternMayIncludeAsset(pattern, asset) {
+  const normalized = normalizeRepoPath(pattern);
+  if (containsRestrictedLiteral(normalized, asset)) return true;
+  const prefix = literalPrefix(normalized);
+  if (prefix === '') return true;
+  return asset.paths.some((root) => isSameOrDescendant(root, prefix));
+}
+
+function patternCoversRoot(pattern, root) {
+  const normalized = normalizeRepoPath(pattern);
+  if (normalized === root || normalized === `${root}/**` || normalized === `${root}/**/*`) return true;
+  const prefix = literalPrefix(normalized);
+  return prefix !== '' && isSameOrDescendant(root, prefix) && /\*\*/u.test(normalized);
+}
+
+function containsRestrictedLiteral(path, asset) {
+  return asset.paths.some((root) => path === root
+    || path.startsWith(`${root}/`)
+    || path.includes(`/${root}/`)
+    || path.endsWith(`/${root}`));
+}
+
+function literalPrefix(pattern) {
+  const index = pattern.search(/[?*[{]/u);
+  const prefix = index === -1 ? pattern : pattern.slice(0, index);
+  return prefix.replace(/\/$/u, '');
+}
+
+function isAllowedMetadata(asset, path) {
+  return asset.distributableMetadata.some((rule) => {
+    if (typeof rule === 'string') return path === rule;
+    rule.lastIndex = 0;
+    return rule.test(path);
+  });
+}
+
+function isSameOrDescendant(path, root) {
+  return path === root || path.startsWith(`${root}/`);
+}
+
+function normalizePattern(path, base) {
+  const slashed = String(path).replaceAll('\\', '/').replace(/^\.\//u, '');
+  if (slashed === '') return normalizeRepoPath(base);
+  if (slashed.startsWith('/')) return posix.normalize(slashed).replace(/^\/+/, '');
+  return normalizeRepoPath(posix.join(base || '.', slashed));
+}
+
+function normalizeRepoPath(path) {
+  return posix.normalize(String(path).replaceAll('\\', '/')).replace(/^\.\//u, '').replace(/^\/+/, '');
+}
+
+function violation(location, path, asset, detail) {
+  return { location, path, asset, detail };
+}
+
+function formatViolation(item) {
+  return `FORBIDDEN: ${item.location} -> ${item.path}  (${item.asset.id}: ${item.asset.license} — ${item.asset.reason} ; ${item.detail})`;
+}
+
+function extractVendorSources(source) {
+  const declaration = /\b(?:const|let|var)\s+VENDOR_SOURCES\s*=\s*\[/gu.exec(source);
+  if (!declaration) throw new Error('VENDOR_SOURCES array literal was not found');
+  const open = declaration.index + declaration[0].lastIndexOf('[');
+  const close = findClosingBracket(source, open);
+  const body = source.slice(open + 1, close);
+  const strings = [];
+  let index = 0;
+  while (index < body.length) {
+    index = skipSpaceAndComments(body, index);
+    if (index >= body.length) break;
+    if (body[index] === ',') { index += 1; continue; }
+    const quote = body[index];
+    if (quote !== "'" && quote !== '"') {
+      throw new Error('VENDOR_SOURCES must contain only string literals');
+    }
+    const parsed = readStringLiteral(body, index, quote);
+    strings.push(parsed.value);
+    index = skipSpaceAndComments(body, parsed.next);
+    if (index < body.length && body[index] !== ',') {
+      throw new Error('VENDOR_SOURCES contains an unsupported expression');
+    }
+  }
+  return strings;
+}
+
+function findClosingBracket(source, open) {
+  let depth = 0;
+  let state = 'code';
+  let quote = '';
+  for (let index = open; index < source.length; index += 1) {
+    const char = source[index];
+    const next = source[index + 1];
+    if (state === 'line-comment') {
+      if (char === '\n') state = 'code';
+      continue;
+    }
+    if (state === 'block-comment') {
+      if (char === '*' && next === '/') { state = 'code'; index += 1; }
+      continue;
+    }
+    if (state === 'string') {
+      if (char === '\\') { index += 1; continue; }
+      if (char === quote) state = 'code';
+      continue;
+    }
+    if (char === '/' && next === '/') { state = 'line-comment'; index += 1; continue; }
+    if (char === '/' && next === '*') { state = 'block-comment'; index += 1; continue; }
+    if (char === "'" || char === '"' || char === '`') { state = 'string'; quote = char; continue; }
+    if (char === '[') depth += 1;
+    if (char === ']' && --depth === 0) return index;
+  }
+  throw new Error('VENDOR_SOURCES array literal is not closed');
+}
+
+function skipSpaceAndComments(source, start) {
+  let index = start;
+  while (index < source.length) {
+    if (/\s/u.test(source[index])) { index += 1; continue; }
+    if (source[index] === '/' && source[index + 1] === '/') {
+      index = source.indexOf('\n', index + 2);
+      if (index === -1) return source.length;
+      continue;
+    }
+    if (source[index] === '/' && source[index + 1] === '*') {
+      const close = source.indexOf('*/', index + 2);
+      if (close === -1) throw new Error('unterminated comment in VENDOR_SOURCES');
+      index = close + 2;
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+
+function readStringLiteral(source, start, quote) {
+  let value = '';
+  for (let index = start + 1; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === quote) return { value, next: index + 1 };
+    if (char === '\\') {
+      const escaped = source[index + 1];
+      if (escaped === undefined) break;
+      value += escaped;
+      index += 1;
+    } else {
+      value += char;
+    }
+  }
+  throw new Error('unterminated string in VENDOR_SOURCES');
+}
+
+function parseArgs(argv) {
+  const options = {};
+  const allowed = new Set(['--repo-root', '--shell-package', '--tracked-files', '--prepack']);
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!allowed.has(key)) throw new Error(`unknown option: ${key}`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`${key} requires a path`);
+    options[key.slice(2)] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function readJson(path, label) {
+  let source;
+  try { source = readFileSync(path, 'utf8'); } catch (error) {
+    throw new Error(`${label} cannot be read: ${messageOf(error)}`);
+  }
+  try {
+    const parsed = JSON.parse(source);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('root must be an object');
+    return parsed;
+  } catch (error) {
+    throw new Error(`${label} is invalid JSON: ${messageOf(error)}`);
+  }
+}
+
+function assertRestrictedPathsExist(repoRoot) {
+  for (const asset of RESTRICTED_ASSETS) {
+    for (const path of asset.paths) {
+      if (!existsSync(resolve(repoRoot, path))) {
+        throw new Error(`restricted path does not exist (${asset.id}): ${path}`);
+      }
+    }
+  }
+}
+
+function resolveOptionPath(value, fallback, repoRoot) {
+  if (value === undefined) return resolve(repoRoot, fallback);
+  return isAbsolute(value) ? value : resolve(process.cwd(), value);
+}
+
+function loadPackageManifests(repoRoot, trackedFiles) {
+  const paths = [...new Set(trackedFiles.filter((path) => posix.basename(normalizeRepoPath(path)) === 'package.json'))].sort();
+  return paths.map((path) => ({ path: normalizeRepoPath(path), manifest: readJson(resolve(repoRoot, path), path) }));
+}
+
+function discoverCapabilitySources(trackedFiles) {
+  return trackedFiles.map(normalizeRepoPath).filter((path) => /^skills\/.+\.md$/u.test(path)
+    || /^docs\/contract-[^/]+\.md$/u.test(path)
+    || /^packages\/[^/]+\/README[^/]*\.md$/u.test(path)
+    || /^packages\/[^/]+\/package\.json$/u.test(path)).sort();
+}
+
+function messageOf(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function runCli() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const repoRoot = resolve(options['repo-root'] ?? DEFAULT_REPO_ROOT);
+    assertRestrictedPathsExist(repoRoot);
+
+    const shellPath = resolveOptionPath(options['shell-package'], 'apps/shell/package.json', repoRoot);
+    const prepackPath = resolveOptionPath(options.prepack, 'packages/akari-launcher/scripts/prepack.mjs', repoRoot);
+    const shellPackage = readJson(shellPath, shellPath);
+    let trackedFiles;
+    if (options['tracked-files']) {
+      const trackedPath = resolveOptionPath(options['tracked-files'], '', repoRoot);
+      trackedFiles = readFileSync(trackedPath, 'utf8').split(/\r?\n/u).filter(Boolean);
+    } else {
+      trackedFiles = execFileSync('git', ['-C', repoRoot, 'ls-files', '-z'], {
+        encoding: 'utf8', maxBuffer: 64 * 1024 * 1024,
+      }).split('\0').filter(Boolean);
+    }
+    const prepackSource = readFileSync(prepackPath, 'utf8');
+    const packageManifests = loadPackageManifests(repoRoot, trackedFiles);
+    const capabilitySources = discoverCapabilitySources(trackedFiles);
+    const violations = [
+      ...checkShellPackage(shellPackage),
+      ...checkTrackedFiles(trackedFiles),
+      ...checkNpmDistribution({ prepackSource, packageManifests, capabilitySources }),
+    ];
+    if (violations.length > 0) {
+      for (const item of violations) console.error(formatViolation(item));
+      console.error(`check-no-gpl-redistribution: FORBIDDEN ${violations.length} 件`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`check-no-gpl-redistribution: OK（restricted ${RESTRICTED_ASSETS.length} 件 / 違反 0）`);
+  } catch (error) {
+    console.error(`check-no-gpl-redistribution: ERROR（fail-closed）: ${messageOf(error)}`);
+    process.exitCode = 1;
+  }
+}
+
+// symlink 経由でも CLI が無言終了しないよう、入口と argv の両辺を realpath で比較する。
+if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(SCRIPT_PATH)) runCli();

--- a/scripts/release/check-packaged-imports.mjs
+++ b/scripts/release/check-packaged-imports.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 // パッケージ版 Resources の静的 import グラフ検査 — 同梱漏れを CI で機械検出する。
 //
-// なぜ要るか: extraResources で配る CLI / ランタイム（render-cut・osr-export・gpu-export・edit-lint・
-// akari-launcher）は、モノレポでは隣の packages/ や skills/ を相対 import で参照できてしまう。
+// なぜ要るか: extraResources で配る CLI / ランタイム（skills/**/bin・render-cut・osr-export・
+// gpu-export・edit-lint・akari-launcher）は、モノレポでは隣の packages/ や skills/ を相対 import で参照できてしまう。
 // パッケージ版の Resources にその参照先が同梱されていないと、import 時点で ERR_MODULE_NOT_FOUND になり
 // 書き出しが全滅する（v0.1.25: packages/gpu-export と skills/analyze-footage/bin/person-matte の同梱漏れ、
 // および @webav/mp4box.js の同梱 node_modules 漏れ。実ビルドで再現・v0.1.26 で修正）。
@@ -12,7 +12,8 @@
 // やること:
 //   1. apps/shell/package.json の build.extraResources を読み、from → to を filter どおり模擬 Resources に
 //      symlink で組む（実ファイルはコピーしない。相対 import の解決は論理パスで行うので symlink で足りる）
-//   2. 入口 = 模擬 Resources 内の packages/*/bin/*.mjs 全部 + osr-export / gpu-export の src/electron-main.mjs
+//   2. 入口 = 模擬 Resources 内の packages/*/bin/*.mjs 全部 + skills/**/bin/**/*.mjs +
+//      osr-export / gpu-export の src/electron-main.mjs
 //   3. 静的 import（import … from / export … from / import "x"）を再帰的に辿る。相対は存在検査、
 //      bare は packages/node_modules（= resources/cli-node-modules）から解決。node: と electron は対象外
 //   4. 動的 import("x") は参考情報（hyperframes のように意図的に同梱しない依存があるため fail にしない）
@@ -176,6 +177,13 @@ export function defaultEntries(resourcesRoot) {
       const binDir = join(packagesDir, name, 'bin');
       if (name === 'node_modules' || !existsSync(binDir)) continue;
       for (const file of readdirSync(binDir)) if (file.endsWith('.mjs')) entries.push(join(binDir, file));
+    }
+  }
+  const skillsDir = join(resourcesRoot, 'skills');
+  if (existsSync(skillsDir)) {
+    for (const file of walkFiles(skillsDir)) {
+      const label = relative(skillsDir, file).split('\\').join('/');
+      if (label.includes('/bin/') && file.endsWith('.mjs')) entries.push(file);
     }
   }
   for (const runtime of ['osr-export', 'gpu-export']) {

--- a/scripts/release/check-packaged-imports.mjs
+++ b/scripts/release/check-packaged-imports.mjs
@@ -16,7 +16,9 @@
 //      osr-export / gpu-export の src/electron-main.mjs
 //   3. 静的 import（import … from / export … from / import "x"）を再帰的に辿る。相対は存在検査、
 //      bare は packages/node_modules（= resources/cli-node-modules）から解決。node: と electron は対象外
-//   4. 動的 import("x") は参考情報（hyperframes のように意図的に同梱しない依存があるため fail にしない）
+//   4. リポジトリのソースツリーにある package 解決関数の文字列リテラル引数を走査し、模擬 Resources
+//      の packages/<pkg>/<rel> に実体があるか検査する。非リテラル引数は参考情報に留める
+//   5. 動的 import("x") は参考情報（hyperframes のように意図的に同梱しない依存があるため fail にしない）
 //
 // 前提: resources/cli-node-modules が staging 済み（scripts/release/install-bundled-cli-deps.mjs →
 // apps/shell/resources/scripts/bundle-cli-node-modules.mjs）。無ければ bare import は全部 missing になる。
@@ -24,10 +26,12 @@
 // 使い方:
 //   node scripts/release/check-packaged-imports.mjs [--shell-package apps/shell/package.json] [--keep]
 // 終了コード: 欠け 0 なら 0、1 件以上なら 1。
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, statSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { RESTRICTED_ASSETS } from './check-no-gpl-redistribution.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(here, '..', '..');
@@ -35,6 +39,19 @@ const args = process.argv.slice(2);
 const shellPackagePath = resolve(REPO_ROOT, args.includes('--shell-package') ? args[args.indexOf('--shell-package') + 1] : 'apps/shell/package.json');
 const SHELL_DIR = resolve(REPO_ROOT, 'apps', 'shell');
 const keep = args.includes('--keep');
+
+// resolvePackageDir はまだ export されていないが、追加時に走査漏れを作らないため同じ正本へ置く。
+export const PACKAGE_RESOLVER_NAMES = new Set([
+  'resolvePackageFile',
+  'resolvePackageDir',
+  'importPackage',
+]);
+
+const RESTRICTED_PACKAGE_NAMES = new Set(RESTRICTED_ASSETS.flatMap((asset) =>
+  asset.paths.flatMap((assetPath) => {
+    const match = /^packages\/([^/]+)$/u.exec(assetPath.replaceAll('\\', '/').replace(/\/$/u, ''));
+    return match ? [match[1]] : [];
+  })));
 
 // electron-builder の filter（from 相対の glob）を正規表現へ。使っている形は
 // `package.json` / `bin/**/*` / `src/**/*` / `generated/**/*` / `*.mjs` / `lib/**` 程度。
@@ -169,6 +186,176 @@ export function walkImports(entries, resourcesRoot) {
   return { walked: seen.size, missing, dynamic };
 }
 
+function sourceFilesForPackageResolvers(repoRoot) {
+  const files = [];
+  const skillsDir = join(repoRoot, 'skills');
+  if (existsSync(skillsDir)) {
+    for (const file of walkFiles(skillsDir)) {
+      const label = relative(skillsDir, file).split('\\').join('/');
+      if (label.includes('/bin/') && !label.includes('/bin/test/') && file.endsWith('.mjs')) files.push(file);
+    }
+  }
+  const packagesDir = join(repoRoot, 'packages');
+  if (existsSync(packagesDir)) {
+    for (const packageName of readdirSync(packagesDir)) {
+      for (const directoryName of ['bin', 'src']) {
+        const directory = join(packagesDir, packageName, directoryName);
+        if (!existsSync(directory) || !statSync(directory).isDirectory()) continue;
+        for (const file of walkFiles(directory)) if (file.endsWith('.mjs')) files.push(file);
+      }
+    }
+  }
+  return [...new Set(files)].sort();
+}
+
+function skipSpaceAndComments(source, start) {
+  let index = start;
+  while (index < source.length) {
+    if (/\s/u.test(source[index])) { index += 1; continue; }
+    if (source[index] === '/' && source[index + 1] === '/') {
+      index = source.indexOf('\n', index + 2);
+      if (index === -1) return source.length;
+      continue;
+    }
+    if (source[index] === '/' && source[index + 1] === '*') {
+      const close = source.indexOf('*/', index + 2);
+      return close === -1 ? source.length : skipSpaceAndComments(source, close + 2);
+    }
+    break;
+  }
+  return index;
+}
+
+function readQuoted(source, start) {
+  const quote = source[start];
+  let value = '';
+  for (let index = start + 1; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === '\\') return null;
+    if (char === quote) return { value, next: index + 1 };
+    if (char === '\n' || char === '\r') return null;
+    value += char;
+  }
+  return null;
+}
+
+function argumentEnd(source, start) {
+  let depth = 0;
+  let state = 'code';
+  let quote = '';
+  for (let index = start; index < source.length; index += 1) {
+    const char = source[index];
+    const next = source[index + 1];
+    if (state === 'line-comment') {
+      if (char === '\n') state = 'code';
+      continue;
+    }
+    if (state === 'block-comment') {
+      if (char === '*' && next === '/') { state = 'code'; index += 1; }
+      continue;
+    }
+    if (state === 'string') {
+      if (char === '\\') { index += 1; continue; }
+      if (char === quote) state = 'code';
+      continue;
+    }
+    if (char === '/' && next === '/') { state = 'line-comment'; index += 1; continue; }
+    if (char === '/' && next === '*') { state = 'block-comment'; index += 1; continue; }
+    if (char === "'" || char === '"' || char === '`') { state = 'string'; quote = char; continue; }
+    if (char === '(' || char === '[' || char === '{') { depth += 1; continue; }
+    if (char === ')' || char === ']' || char === '}') {
+      if (depth === 0 && char === ')') return index;
+      depth -= 1;
+      continue;
+    }
+    if (char === ',' && depth === 0) return index;
+  }
+  return source.length;
+}
+
+function resolverCalls(source) {
+  const calls = [];
+  let index = 0;
+  while (index < source.length) {
+    if (source[index] === '/' && source[index + 1] === '/') {
+      const newline = source.indexOf('\n', index + 2);
+      index = newline === -1 ? source.length : newline + 1;
+      continue;
+    }
+    if (source[index] === '/' && source[index + 1] === '*') {
+      const close = source.indexOf('*/', index + 2);
+      index = close === -1 ? source.length : close + 2;
+      continue;
+    }
+    if (source[index] === "'" || source[index] === '"' || source[index] === '`') {
+      const quote = source[index];
+      index += 1;
+      while (index < source.length) {
+        if (source[index] === '\\') { index += 2; continue; }
+        if (source[index] === quote) { index += 1; break; }
+        index += 1;
+      }
+      continue;
+    }
+    if (!/[A-Za-z_$]/u.test(source[index])) { index += 1; continue; }
+    const start = index;
+    index += 1;
+    while (index < source.length && /[A-Za-z0-9_$]/u.test(source[index])) index += 1;
+    const resolver = source.slice(start, index);
+    if (!PACKAGE_RESOLVER_NAMES.has(resolver)) continue;
+    if (/\bfunction\s*$/u.test(source.slice(Math.max(0, start - 30), start))) continue;
+    const open = skipSpaceAndComments(source, index);
+    if (source[open] !== '(') continue;
+    const argumentStart = skipSpaceAndComments(source, open + 1);
+    const end = argumentEnd(source, argumentStart);
+    const expression = source.slice(argumentStart, end).trim().replace(/\s+/gu, ' ').slice(0, 160);
+    const quoted = source[argumentStart] === "'" || source[argumentStart] === '"'
+      ? readQuoted(source, argumentStart)
+      : null;
+    const afterQuoted = quoted ? skipSpaceAndComments(source, quoted.next) : -1;
+    const literal = quoted && (source[afterQuoted] === ',' || source[afterQuoted] === ')')
+      ? quoted.value
+      : null;
+    calls.push({ resolver, literal, expression, line: source.slice(0, start).split('\n').length });
+    index = Math.max(index, end);
+  }
+  return calls;
+}
+
+// 実ソースツリーの package 解決呼び出しを、組み上げ済みの模擬 Resources と照合する。
+export function scanPackageResolverCalls({ repoRoot = REPO_ROOT, resourcesRoot }) {
+  const missing = [];
+  const excluded = [];
+  const dynamic = [];
+  let found = 0;
+  const files = sourceFilesForPackageResolvers(repoRoot);
+  for (const file of files) {
+    const sourceLabel = relative(repoRoot, file).split('\\').join('/');
+    for (const call of resolverCalls(readFileSync(file, 'utf8'))) {
+      if (!call.literal) {
+        dynamic.push({ resolver: call.resolver, expression: call.expression || '(empty)', from: sourceLabel, line: call.line });
+        continue;
+      }
+      const normalized = call.literal.replaceAll('\\', '/').replace(/^\/+|\/+$/gu, '');
+      const [packageName, ...rest] = normalized.split('/');
+      if (!packageName || rest.length === 0 || normalized.includes('../')) {
+        dynamic.push({ resolver: call.resolver, expression: call.expression, from: sourceLabel, line: call.line });
+        continue;
+      }
+      found += 1;
+      const item = {
+        resolver: call.resolver,
+        specifier: `packages/${normalized}`,
+        from: sourceLabel,
+        line: call.line,
+      };
+      if (RESTRICTED_PACKAGE_NAMES.has(packageName)) excluded.push(item);
+      else if (!existsSync(join(resourcesRoot, 'packages', normalized))) missing.push(item);
+    }
+  }
+  return { scanned: files.length, found, missing, excluded, dynamic };
+}
+
 export function defaultEntries(resourcesRoot) {
   const entries = [];
   const packagesDir = join(resourcesRoot, 'packages');
@@ -193,13 +380,14 @@ export function defaultEntries(resourcesRoot) {
   return entries.sort();
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))) {
   const shellPackage = JSON.parse(readFileSync(shellPackagePath, 'utf8'));
   const resourcesRoot = join(mkdtempSync(join(tmpdir(), 'akari-packaged-')), 'Resources');
   mkdirSync(resourcesRoot, { recursive: true });
   const { skipped } = assembleResources(shellPackage, { resourcesRoot });
   const entries = defaultEntries(resourcesRoot);
   const { walked, missing, dynamic } = walkImports(entries, resourcesRoot);
+  const packageResolvers = scanPackageResolverCalls({ resourcesRoot });
   console.log(`check-packaged-imports: entries ${entries.length} / walked ${walked} files / Resources = ${resourcesRoot}`);
   if (skipped.length > 0) console.log(`  skipped (from が存在しない・生成物など): ${skipped.join(', ')}`);
   for (const entry of entries) console.log(`  entry: ${relative(resourcesRoot, entry)}`);
@@ -207,9 +395,29 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
     console.log(`  dynamic import（参考・fail にしない）: ${dynamic.length}`);
     for (const item of dynamic) console.log(`    ${item.specifier}  <- ${item.from}`);
   }
+  if (packageResolvers.dynamic.length > 0) {
+    console.log(`  package resolver の非リテラル引数（参考・fail にしない）: ${packageResolvers.dynamic.length}`);
+    for (const item of packageResolvers.dynamic) {
+      console.log(`    (${item.resolver}) ${item.expression}  <- ${item.from}:${item.line}`);
+    }
+  }
+  if (packageResolvers.excluded.length > 0) {
+    console.log(`  package resolver 除外（restricted・fail にしない）: ${packageResolvers.excluded.length}`);
+    for (const item of packageResolvers.excluded) {
+      console.log(`    除外した: (${item.resolver}) ${item.specifier}  <- ${item.from}:${item.line}`);
+    }
+  }
+  if (packageResolvers.missing.length > 0) {
+    console.error(`check-packaged-imports: PACKAGE RESOLVER MISSING ${packageResolvers.missing.length}`);
+    for (const item of packageResolvers.missing) {
+      console.error(`    (${item.resolver}) ${item.specifier}  <- ${item.from}:${item.line}`);
+    }
+  }
   if (missing.length > 0) {
     console.error(`check-packaged-imports: MISSING ${missing.length}（パッケージ版で ERR_MODULE_NOT_FOUND になる）`);
     for (const item of missing) console.error(`    ${item.specifier}  <- imported from ${item.from}`);
+  }
+  if (missing.length > 0 || packageResolvers.missing.length > 0) {
     if (!keep) rmSync(dirname(resourcesRoot), { recursive: true, force: true });
     process.exit(1);
   }

--- a/scripts/test/check-no-gpl-redistribution.test.mjs
+++ b/scripts/test/check-no-gpl-redistribution.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import { checkNpmDistribution } from '../release/check-no-gpl-redistribution.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const GUARD = join(REPO_ROOT, 'scripts/release/check-no-gpl-redistribution.mjs');
+
+function runGuard(args = []) {
+  return spawnSync(process.execPath, [GUARD, ...args], { cwd: REPO_ROOT, encoding: 'utf8' });
+}
+
+function temporaryDirectory(t) {
+  const directory = mkdtempSync(join(tmpdir(), 'akari-no-gpl-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+test('実リポジトリは再配布ガードを通過する', () => {
+  const result = runGuard();
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /OK（restricted 1 件 \/ 違反 0）/u);
+});
+
+test('メタ: shell extraResources へ RVM 実装を足すと CLI が落ち、理由を出す', (t) => {
+  const directory = temporaryDirectory(t);
+  const shellPackage = JSON.parse(readFileSync(join(REPO_ROOT, 'apps/shell/package.json'), 'utf8'));
+  shellPackage.build.extraResources.push({
+    from: '../../packages/matte-rvm',
+    to: 'packages/matte-rvm',
+    filter: ['package.json', 'bin/**/*', 'src/**/*'],
+  });
+  const shellPath = join(directory, 'package.json');
+  writeFileSync(shellPath, `${JSON.stringify(shellPackage, null, 2)}\n`);
+
+  const result = runGuard(['--shell-package', shellPath]);
+  assert.notEqual(result.status, 0, result.stdout);
+  assert.match(result.stderr, /FORBIDDEN:.*packages\/matte-rvm.*GPL-3\.0/u);
+});
+
+test('メタ: vendor の ONNX を追跡対象へ足すと CLI が落ち、理由を出す', (t) => {
+  const directory = temporaryDirectory(t);
+  const tracked = execFileSync('git', ['-C', REPO_ROOT, 'ls-files'], { encoding: 'utf8' });
+  const trackedPath = join(directory, 'tracked-files.txt');
+  writeFileSync(trackedPath, `${tracked.trimEnd()}\npackages/matte-rvm/vendor/rvm_mobilenetv3_fp32.onnx\n`);
+
+  const result = runGuard(['--tracked-files', trackedPath]);
+  assert.notEqual(result.status, 0, result.stdout);
+  assert.match(result.stderr, /FORBIDDEN:.*vendor\/rvm_mobilenetv3_fp32\.onnx/u);
+});
+
+test('メタ: prepack VENDOR_SOURCES へ RVM src を足すと CLI が落ちる', (t) => {
+  const directory = temporaryDirectory(t);
+  const source = readFileSync(join(REPO_ROOT, 'packages/akari-launcher/scripts/prepack.mjs'), 'utf8');
+  const modified = source.replace('const VENDOR_SOURCES = [', "const VENDOR_SOURCES = [\n  'packages/matte-rvm/src',");
+  assert.notEqual(modified, source);
+  const prepackPath = join(directory, 'prepack.mjs');
+  writeFileSync(prepackPath, modified);
+
+  const result = runGuard(['--prepack', prepackPath]);
+  assert.notEqual(result.status, 0, result.stdout);
+  assert.match(result.stderr, /FORBIDDEN:.*packages\/matte-rvm\/src.*GPL-3\.0/u);
+});
+
+test('package.json#files が RVM を配布対象にすると純粋検査が落とす', () => {
+  const violations = checkNpmDistribution({
+    prepackSource: 'const VENDOR_SOURCES = [];',
+    packageManifests: [{ path: 'package.json', manifest: { files: ['packages/matte-rvm/src/**/*'] } }],
+    capabilitySources: [],
+  });
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].path, /matte-rvm\/src/u);
+});
+
+test('capability source の自作 metadata だけは allowlist が許可する', () => {
+  const violations = checkNpmDistribution({
+    prepackSource: 'const VENDOR_SOURCES = [];',
+    packageManifests: [],
+    capabilitySources: ['packages/matte-rvm/package.json', 'packages/matte-rvm/README.md'],
+  });
+  assert.deepEqual(violations, []);
+});
+
+test('fail-closed: restricted path が存在しない repo root では CLI が落ちる', (t) => {
+  const directory = temporaryDirectory(t);
+  const result = runGuard(['--repo-root', directory]);
+  assert.notEqual(result.status, 0, result.stdout);
+  assert.match(result.stderr, /fail-closed.*restricted path does not exist/u);
+});

--- a/scripts/test/check-packaged-imports.test.mjs
+++ b/scripts/test/check-packaged-imports.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import { assembleResources, scanPackageResolverCalls } from '../release/check-packaged-imports.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const GUARD = join(REPO_ROOT, 'scripts/release/check-packaged-imports.mjs');
+const SHELL_PACKAGE = join(REPO_ROOT, 'apps/shell/package.json');
+
+function temporaryDirectory(t) {
+  const directory = mkdtempSync(join(tmpdir(), 'akari-packaged-imports-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+function runGuard(shellPackagePath = SHELL_PACKAGE) {
+  return spawnSync(process.execPath, [GUARD, '--shell-package', shellPackagePath], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+}
+
+function shellPackageWithout(t, packageName) {
+  const directory = temporaryDirectory(t);
+  const shellPackage = JSON.parse(readFileSync(SHELL_PACKAGE, 'utf8'));
+  const destination = `packages/${packageName}`;
+  const before = shellPackage.build.extraResources.length;
+  shellPackage.build.extraResources = shellPackage.build.extraResources.filter((entry) =>
+    typeof entry === 'string' || (entry.to !== destination && !entry.to?.startsWith(`${destination}/`)));
+  assert.equal(shellPackage.build.extraResources.length, before - 1, `${destination} fixture entry`);
+  const path = join(directory, 'package.json');
+  writeFileSync(path, `${JSON.stringify(shellPackage, null, 2)}\n`);
+  return path;
+}
+
+test('実 Resources は解決関数走査を通り、restricted package を除外する', (t) => {
+  const directory = temporaryDirectory(t);
+  const resourcesRoot = join(directory, 'Resources');
+  mkdirSync(resourcesRoot, { recursive: true });
+  const shellPackage = JSON.parse(readFileSync(SHELL_PACKAGE, 'utf8'));
+  assembleResources(shellPackage, { resourcesRoot });
+
+  const result = scanPackageResolverCalls({ repoRoot: REPO_ROOT, resourcesRoot });
+  assert.deepEqual(result.missing, []);
+  assert.ok(result.excluded.some((item) =>
+    item.resolver === 'importPackage' && item.specifier === 'packages/matte-rvm/src/index.mjs'));
+});
+
+test('非リテラルの変数・テンプレート・連結は参考情報に留める', (t) => {
+  const directory = temporaryDirectory(t);
+  const repoRoot = join(directory, 'repo');
+  const resourcesRoot = join(directory, 'Resources');
+  const sourceDir = join(repoRoot, 'skills/sample/bin');
+  mkdirSync(sourceDir, { recursive: true });
+  mkdirSync(join(resourcesRoot, 'packages'), { recursive: true });
+  writeFileSync(join(sourceDir, 'sample.mjs'), [
+    'resolvePackageFile(variable);',
+    'resolvePackageDir(`sample/${part}`);',
+    'importPackage("sample/" + part);',
+    'resolvePackageFile("needed/src/index.mjs");',
+  ].join('\n'));
+
+  const result = scanPackageResolverCalls({ repoRoot, resourcesRoot });
+  assert.equal(result.dynamic.length, 3);
+  assert.equal(result.missing.length, 1);
+  assert.equal(result.missing[0].specifier, 'packages/needed/src/index.mjs');
+});
+
+for (const [packageName, expectedResolver, expectedSource] of [
+  ['chat-bridge', 'importPackage', 'skills/setup-chat-approval/bin/doctor.mjs'],
+  ['creator-root', 'importPackage', 'skills/manage-connections/bin/doctor.mjs'],
+  ['media-bin', 'importPackage', 'skills/analyze-footage/bin/person-matte/person-matte.mjs'],
+  ['edit-store', 'resolvePackageFile', 'skills/analyze-footage/bin/person-matte/person-cutout.mjs'],
+  ['schemas', 'resolvePackageFile', 'skills/analyze-footage/bin/person-matte/person-cutout.mjs'],
+]) {
+  test(`解決関数走査は ${packageName} の同梱漏れを名指しする`, (t) => {
+    const shellPackagePath = shellPackageWithout(t, packageName);
+    const result = runGuard(shellPackagePath);
+    assert.equal(result.status, 1, result.stdout);
+    assert.match(result.stderr, /PACKAGE RESOLVER MISSING/u);
+    assert.match(
+      result.stderr,
+      new RegExp(`\\(${expectedResolver}\\) packages/${packageName}/[^\\s]+\\s+<- ${expectedSource.replaceAll('.', '\\.')}`, 'u'),
+    );
+  });
+}

--- a/skills/analyze-footage/bin/person-matte/mask-from-alpha.mjs
+++ b/skills/analyze-footage/bin/person-matte/mask-from-alpha.mjs
@@ -5,9 +5,18 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-import { resolveFfmpeg, resolveFfprobe } from "../../../../packages/media-bin/src/index.mjs";
 import { findAlphaModeTag } from "./alpha-tag.mjs";
 import { MASK_FORMAT, maskOutputArguments } from "./mask-format.mjs";
+import { importPackage } from "./resolve-packages.mjs";
+
+let dependencyError = null;
+let resolveFfmpeg;
+let resolveFfprobe;
+try {
+  ({ resolveFfmpeg, resolveFfprobe } = await importPackage("media-bin/src/index.mjs", { from: import.meta.url }));
+} catch (error) {
+  dependencyError = error;
+}
 
 const scriptPath = fileURLToPath(import.meta.url);
 
@@ -137,6 +146,7 @@ export function ensureMask(webmPath, options = {}) {
   const output = path.resolve(options.out ?? maskPathFor(input));
   const result = { ok: false, path: output, skipped: false, reason: null, elapsedMs: 0 };
   try {
+    if (dependencyError && (!options.ffmpeg || !options.ffprobe)) throw dependencyError;
     const inputStat = fs.statSync(input);
     if (!inputStat.isFile()) throw new Error(`入力が通常ファイルではありません: ${input}`);
     if (!options.force) {
@@ -241,6 +251,10 @@ function isMainModule() {
 }
 
 if (isMainModule()) {
+  if (dependencyError) {
+    console.error(dependencyError.message);
+    process.exit(1);
+  }
   let response;
   try {
     const options = parseArguments(process.argv.slice(2));

--- a/skills/analyze-footage/bin/person-matte/mask-roundtrip.mjs
+++ b/skills/analyze-footage/bin/person-matte/mask-roundtrip.mjs
@@ -11,8 +11,17 @@ import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-import { resolveFfmpeg, resolveFfprobe } from "../../../../packages/media-bin/src/index.mjs";
 import { probeAlphaSource } from "./mask-from-alpha.mjs";
+import { importPackage } from "./resolve-packages.mjs";
+
+let dependencyError = null;
+let resolveFfmpeg;
+let resolveFfprobe;
+try {
+  ({ resolveFfmpeg, resolveFfprobe } = await importPackage("media-bin/src/index.mjs", { from: import.meta.url }));
+} catch (error) {
+  dependencyError = error;
+}
 
 const scriptPath = fileURLToPath(import.meta.url);
 
@@ -79,6 +88,7 @@ function stats(histogram, count, total, maximum) {
 }
 
 export async function compareRoundtrip(alphaPath, maskPath, options = {}) {
+  if (dependencyError && (!options.ffmpeg || !options.ffprobe)) throw dependencyError;
   const ffmpeg = options.ffmpeg ?? resolveFfmpeg();
   const ffprobe = options.ffprobe ?? resolveFfprobe();
   const alphaProbe = probeAlphaSource(alphaPath, { ffprobe });
@@ -194,6 +204,10 @@ function isMainModule() {
 }
 
 if (isMainModule()) {
+  if (dependencyError) {
+    console.error(dependencyError.message);
+    process.exit(1);
+  }
   try {
     const options = parseArguments(process.argv.slice(2));
     const result = await compareRoundtrip(options.alpha, options.mask, options);

--- a/skills/analyze-footage/bin/person-matte/person-cutout.mjs
+++ b/skills/analyze-footage/bin/person-matte/person-cutout.mjs
@@ -11,15 +11,24 @@ import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
-import { resolveFfmpeg } from "../../../../packages/media-bin/src/index.mjs";
+import { importPackage, resolvePackageFile } from "./resolve-packages.mjs";
 
 const require = createRequire(import.meta.url);
-const { readEditV2 } = require("../../../../packages/edit-store/lib/index.js");
+let dependencyError = null;
+let resolveFfmpeg;
+let readEditV2;
+let validateEditScript;
+try {
+  ({ resolveFfmpeg } = await importPackage("media-bin/src/index.mjs", { from: import.meta.url }));
+  ({ readEditV2 } = require(resolvePackageFile("edit-store/lib/index.js", { from: import.meta.url })));
+  validateEditScript = resolvePackageFile("schemas/bin/validate-edit.mjs", { from: import.meta.url });
+} catch (error) {
+  dependencyError = error;
+}
 
 const scriptPath = fileURLToPath(import.meta.url);
 const scriptDir = path.dirname(scriptPath);
 const personMatteScript = path.join(scriptDir, "person-matte.mjs");
-const validateEditScript = path.resolve(scriptDir, "../../../../packages/schemas/bin/validate-edit.mjs");
 
 const QUALITIES = ["fast", "balanced", "accurate", "best"];
 const MODELS = ["mobilenetv3", "resnet50"];
@@ -365,6 +374,7 @@ function validateAndWrite(editPath, edit) {
 }
 
 async function execute(options) {
+  if (dependencyError) throw dependencyError;
   const { edit, editPath } = readProjectEdit(options.project);
   const plans = resolveCutPlans(edit, options.cuts, options.project);
   const patched = buildPatchedEdit(edit, plans);
@@ -440,7 +450,13 @@ function isMainModule() {
   }
 }
 
-if (isMainModule()) await main();
+if (isMainModule()) {
+  if (dependencyError) {
+    console.error(dependencyError.message);
+    process.exit(1);
+  }
+  await main();
+}
 
 export {
   DEFAULT_QUALITY,

--- a/skills/analyze-footage/bin/person-matte/person-matte.mjs
+++ b/skills/analyze-footage/bin/person-matte/person-matte.mjs
@@ -43,6 +43,7 @@ async function loadRvmPackage() {
     const rvm = await importPackage("matte-rvm/src/index.mjs", { from: import.meta.url });
     return {
       resolveModel: rvm.resolveRvmModel,
+      resolveRuntime: rvm.resolveRvmRuntime,
       helper: resolvePackageFile("matte-rvm/bin/rvm-helper.mjs", { from: import.meta.url }),
     };
   } catch {
@@ -66,6 +67,9 @@ const DEFAULT_RVM_MODEL = "mobilenetv3";
 const TOOL_ID = "vision-person-segmentation";
 const RVM_TOOL_ID = "rvm-person-matting";
 const RVM_UNAVAILABLE_REASON = "RVM が入っていないため、この品質では人物マットを生成できません";
+const RVM_RUNTIME_UNAVAILABLE_REASON =
+  "RVM の実行環境が入っていないため、この品質では人物マットを生成できません";
+const RVM_RUNTIME_INSTALL_HINT = "cd packages/matte-rvm && npm install";
 
 function printJson(value) {
   process.stdout.write(`${JSON.stringify(value)}\n`);
@@ -90,6 +94,7 @@ function checkAvailability({
   resolveFfmpegBin = resolveFfmpeg,
   resolveFfprobeBin = resolveFfprobe,
   resolveModel,
+  resolveRuntime,
   fileExists = fs.existsSync,
 } = {}) {
   if (platform !== "darwin" && platform !== "win32") {
@@ -149,11 +154,24 @@ function checkAvailability({
     if (typeof resolveModel !== "function") {
       return { available: false, reason: RVM_UNAVAILABLE_REASON };
     }
+    if (typeof resolveRuntime !== "function") {
+      return {
+        available: false,
+        reason: `${RVM_RUNTIME_UNAVAILABLE_REASON}。直すには ${RVM_RUNTIME_INSTALL_HINT} を実行してください`,
+      };
+    }
+    const runtime = resolveRuntime();
+    if (!runtime.available) {
+      return {
+        available: false,
+        reason: `${runtime.reason ?? RVM_RUNTIME_UNAVAILABLE_REASON}。直すには ${runtime.installHint ?? RVM_RUNTIME_INSTALL_HINT} を実行してください`,
+      };
+    }
     const model = resolveModel(DEFAULT_RVM_MODEL);
     if (model.missing) {
       return {
         available: false,
-        reason: `RVM model is not installed: ${model.path}. ${model.fetchHint}`,
+        reason: `${RVM_UNAVAILABLE_REASON}。直すには ${model.fetchHint} を実行してください`,
       };
     }
   }
@@ -262,14 +280,28 @@ function engineForPlatform(quality, platform = os.platform()) {
 function prepareExecution(options, {
   platform = os.platform(),
   resolveModel,
+  resolveRuntime,
   buildVisionHelper = buildHelper,
 } = {}) {
   const engine = engineForPlatform(options.quality, platform);
   if (engine === "rvm") {
-    if (typeof resolveModel !== "function") throw new Error(RVM_UNAVAILABLE_REASON);
+    if (typeof resolveModel !== "function") {
+      throw new Error(RVM_UNAVAILABLE_REASON);
+    }
+    if (typeof resolveRuntime !== "function") {
+      throw new Error(
+        `${RVM_RUNTIME_UNAVAILABLE_REASON}。直すには ${RVM_RUNTIME_INSTALL_HINT} を実行してください`,
+      );
+    }
+    const runtime = resolveRuntime();
+    if (!runtime.available) {
+      throw new Error(
+        `${runtime.reason ?? RVM_RUNTIME_UNAVAILABLE_REASON}。直すには ${runtime.installHint ?? RVM_RUNTIME_INSTALL_HINT} を実行してください`,
+      );
+    }
     const resolved = resolveModel(options.model);
     if (resolved.missing) {
-      throw new Error(`RVM model is not installed: ${resolved.path}. ${resolved.fetchHint}`);
+      throw new Error(`${RVM_UNAVAILABLE_REASON}。直すには ${resolved.fetchHint} を実行してください`);
     }
     return { ...options, engine, modelPath: resolved.path };
   }
@@ -639,24 +671,39 @@ async function main() {
   await loadMediaPackage();
   const platform = os.platform();
   const engine = engineForPlatform(options.quality, platform);
-  const rvm = engine === "rvm" ? await loadRvmPackage() : null;
-  let availability = checkAvailability({ platform, resolveModel: rvm?.resolveModel });
-  if (engine === "rvm" && !rvm && availability.available) {
+  const rvm = engine === "rvm" || options.check ? await loadRvmPackage() : null;
+  let availability = checkAvailability({
+    platform,
+    resolveModel: rvm?.resolveModel,
+    resolveRuntime: rvm?.resolveRuntime,
+  });
+  if (engine === "rvm" && availability.available && !rvm) {
     availability = { available: false, reason: RVM_UNAVAILABLE_REASON };
-  } else if (engine === "rvm" && rvm) {
-    const executionModel = rvm.resolveModel(options.model);
-    if (executionModel.missing) {
+  } else if (engine === "rvm" && availability.available && rvm) {
+    const executionRuntime = rvm.resolveRuntime();
+    if (!executionRuntime.available) {
       availability = {
         available: false,
-        reason: `RVM model is not installed: ${executionModel.path}. ${executionModel.fetchHint}`,
+        reason: `${executionRuntime.reason ?? RVM_RUNTIME_UNAVAILABLE_REASON}。直すには ${executionRuntime.installHint ?? RVM_RUNTIME_INSTALL_HINT} を実行してください`,
       };
+    } else {
+      const executionModel = rvm.resolveModel(options.model);
+      if (executionModel.missing) {
+        availability = {
+          available: false,
+          reason: `${RVM_UNAVAILABLE_REASON}。直すには ${executionModel.fetchHint} を実行してください`,
+        };
+      }
     }
   }
   if (options.check) {
     const rvmModel = rvm
       ? rvm.resolveModel(DEFAULT_RVM_MODEL)
       : { model: DEFAULT_RVM_MODEL, missing: true, reason: RVM_UNAVAILABLE_REASON };
-    printJson({ ...availability, rvm_model: rvmModel });
+    const rvmRuntime = rvm
+      ? rvm.resolveRuntime()
+      : { available: false, reason: RVM_RUNTIME_UNAVAILABLE_REASON, installHint: RVM_RUNTIME_INSTALL_HINT };
+    printJson({ ...availability, rvm_model: rvmModel, rvm_runtime: rvmRuntime });
     return;
   }
   if (!options.input || !options.out) {
@@ -671,7 +718,11 @@ async function main() {
   }
 
   try {
-    const prepared = prepareExecution(options, { platform, resolveModel: rvm?.resolveModel });
+    const prepared = prepareExecution(options, {
+      platform,
+      resolveModel: rvm?.resolveModel,
+      resolveRuntime: rvm?.resolveRuntime,
+    });
     if (prepared.engine === "rvm") prepared.rvmHelper = rvm?.helper;
     printJson(await generate(prepared));
   } catch (error) {

--- a/skills/analyze-footage/bin/person-matte/person-matte.mjs
+++ b/skills/analyze-footage/bin/person-matte/person-matte.mjs
@@ -27,15 +27,32 @@ import { fileURLToPath } from "node:url";
 
 import { findAlphaModeTag } from "./alpha-tag.mjs";
 import { MASK_FORMAT, maskOutputArguments } from "./mask-format.mjs";
-import { DEFAULT_RVM_MODEL, resolveRvmModel } from "../../../../packages/matte-rvm/src/index.mjs";
-import { resolveFfmpeg, resolveFfprobe } from "../../../../packages/media-bin/src/index.mjs";
+import { importPackage, resolvePackageFile } from "./resolve-packages.mjs";
+
+let resolveFfmpeg;
+let resolveFfprobe;
+
+async function loadMediaPackage() {
+  const media = await importPackage("media-bin/src/index.mjs", { from: import.meta.url });
+  resolveFfmpeg = media.resolveFfmpeg;
+  resolveFfprobe = media.resolveFfprobe;
+}
+
+async function loadRvmPackage() {
+  try {
+    const rvm = await importPackage("matte-rvm/src/index.mjs", { from: import.meta.url });
+    return {
+      resolveModel: rvm.resolveRvmModel,
+      helper: resolvePackageFile("matte-rvm/bin/rvm-helper.mjs", { from: import.meta.url }),
+    };
+  } catch {
+    return null;
+  }
+}
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const helperSource = path.join(scriptDir, "person-matte-helper.swift");
 const defaultHelperBin = path.join(scriptDir, "person-matte-helper");
-const rvmHelper = fileURLToPath(
-  new URL("../../../../packages/matte-rvm/bin/rvm-helper.mjs", import.meta.url),
-);
 
 // スパイク実測（2026-07-23）で確定した既定値。入力解像度は Vision の速度にほぼ無関係
 // （quality ごとに内部で固定リサイズされる）ため、デコード幅は 1280 で統一する。
@@ -44,8 +61,11 @@ const DEFAULT_FPS = 24;
 const DEFAULT_QUALITY = "balanced";
 const QUALITIES = ["fast", "balanced", "accurate", "best"];
 const RVM_MODELS = ["mobilenetv3", "resnet50"];
+// packages/matte-rvm の正本と同じ既定モデル名を、RVM 未読込の経路でも使えるよう保持する。
+const DEFAULT_RVM_MODEL = "mobilenetv3";
 const TOOL_ID = "vision-person-segmentation";
 const RVM_TOOL_ID = "rvm-person-matting";
+const RVM_UNAVAILABLE_REASON = "RVM が入っていないため、この品質では人物マットを生成できません";
 
 function printJson(value) {
   process.stdout.write(`${JSON.stringify(value)}\n`);
@@ -69,19 +89,27 @@ function checkAvailability({
   runSync = spawnSyncSafe,
   resolveFfmpegBin = resolveFfmpeg,
   resolveFfprobeBin = resolveFfprobe,
-  resolveModel = resolveRvmModel,
+  resolveModel,
+  fileExists = fs.existsSync,
 } = {}) {
   if (platform !== "darwin" && platform !== "win32") {
     return { available: false, reason: `未対応のプラットフォームです（${platform}）` };
   }
 
   if (platform === "darwin") {
-    const swift = runSync("swiftc", ["-version"]);
-    if (swift.error?.code === "ENOENT") {
-      return { available: false, reason: "swiftc が PATH 上にありません" };
+    const hasHelperSource = fileExists(helperSource);
+    const hasBuiltHelper = fileExists(defaultHelperBin);
+    if (!hasHelperSource && !hasBuiltHelper) {
+      return { available: false, reason: "Vision の人物マット用ヘルパーがありません" };
     }
-    if (swift.error || swift.status !== 0) {
-      return { available: false, reason: "swiftc を起動できません" };
+    if (hasHelperSource) {
+      const swift = runSync("swiftc", ["-version"]);
+      if (swift.error?.code === "ENOENT") {
+        return { available: false, reason: "swiftc が PATH 上にありません" };
+      }
+      if (swift.error || swift.status !== 0) {
+        return { available: false, reason: "swiftc を起動できません" };
+      }
     }
   }
 
@@ -118,6 +146,9 @@ function checkAvailability({
   }
 
   if (platform === "win32") {
+    if (typeof resolveModel !== "function") {
+      return { available: false, reason: RVM_UNAVAILABLE_REASON };
+    }
     const model = resolveModel(DEFAULT_RVM_MODEL);
     if (model.missing) {
       return {
@@ -197,7 +228,13 @@ function parseArguments(argv) {
 }
 
 function needsBuild(helperBin) {
-  const sourceStat = fs.statSync(helperSource);
+  let sourceStat;
+  try {
+    sourceStat = fs.statSync(helperSource);
+  } catch (error) {
+    if (error?.code === "ENOENT" && fs.existsSync(helperBin)) return false;
+    throw error;
+  }
   try {
     return fs.statSync(helperBin).mtimeMs < sourceStat.mtimeMs;
   } catch (error) {
@@ -224,11 +261,12 @@ function engineForPlatform(quality, platform = os.platform()) {
 
 function prepareExecution(options, {
   platform = os.platform(),
-  resolveModel = resolveRvmModel,
+  resolveModel,
   buildVisionHelper = buildHelper,
 } = {}) {
   const engine = engineForPlatform(options.quality, platform);
   if (engine === "rvm") {
+    if (typeof resolveModel !== "function") throw new Error(RVM_UNAVAILABLE_REASON);
     const resolved = resolveModel(options.model);
     if (resolved.missing) {
       throw new Error(`RVM model is not installed: ${resolved.path}. ${resolved.fetchHint}`);
@@ -341,7 +379,7 @@ async function generate(options) {
       "segment",
       process.execPath,
       [
-        rvmHelper,
+        options.rvmHelper,
         "--width", String(size.width),
         "--height", String(size.height),
         "--model", options.modelPath,
@@ -598,10 +636,27 @@ async function main() {
     return;
   }
 
+  await loadMediaPackage();
   const platform = os.platform();
-  const availability = checkAvailability({ platform });
+  const engine = engineForPlatform(options.quality, platform);
+  const rvm = engine === "rvm" ? await loadRvmPackage() : null;
+  let availability = checkAvailability({ platform, resolveModel: rvm?.resolveModel });
+  if (engine === "rvm" && !rvm && availability.available) {
+    availability = { available: false, reason: RVM_UNAVAILABLE_REASON };
+  } else if (engine === "rvm" && rvm) {
+    const executionModel = rvm.resolveModel(options.model);
+    if (executionModel.missing) {
+      availability = {
+        available: false,
+        reason: `RVM model is not installed: ${executionModel.path}. ${executionModel.fetchHint}`,
+      };
+    }
+  }
   if (options.check) {
-    printJson({ ...availability, rvm_model: resolveRvmModel(DEFAULT_RVM_MODEL) });
+    const rvmModel = rvm
+      ? rvm.resolveModel(DEFAULT_RVM_MODEL)
+      : { model: DEFAULT_RVM_MODEL, missing: true, reason: RVM_UNAVAILABLE_REASON };
+    printJson({ ...availability, rvm_model: rvmModel });
     return;
   }
   if (!options.input || !options.out) {
@@ -616,7 +671,8 @@ async function main() {
   }
 
   try {
-    const prepared = prepareExecution(options, { platform });
+    const prepared = prepareExecution(options, { platform, resolveModel: rvm?.resolveModel });
+    if (prepared.engine === "rvm") prepared.rvmHelper = rvm?.helper;
     printJson(await generate(prepared));
   } catch (error) {
     printJson({ ok: false, reason: summarize(error?.message, "人物マットの生成に失敗しました") });
@@ -633,7 +689,14 @@ function isMainModule() {
   }
 }
 
-if (isMainModule()) await main();
+if (isMainModule()) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error?.message ?? "人物マットを開始できませんでした。");
+    process.exit(1);
+  }
+}
 
 export {
   DEFAULT_DECODE_WIDTH,

--- a/skills/analyze-footage/bin/person-matte/resolve-packages.mjs
+++ b/skills/analyze-footage/bin/person-matte/resolve-packages.mjs
@@ -1,0 +1,58 @@
+import { existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SETUP_GUIDE = "セットアップするには次を実行してください: curl -fsSL https://raw.githubusercontent.com/AkariLabs/akari-video/main/install.sh | bash";
+
+function startDirectory(from) {
+  const value = from instanceof URL || String(from).startsWith("file:")
+    ? fileURLToPath(from)
+    : path.resolve(String(from));
+  try {
+    if (statSync(value).isDirectory()) return value;
+  } catch {
+    // 存在しないファイル位置も呼び出し元として扱えるよう、親から探索する。
+  }
+  return path.dirname(value);
+}
+
+function packageFile(root, relative) {
+  const candidate = path.resolve(root, "packages", relative);
+  try {
+    return statSync(candidate).isFile() ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolvePackageFile(relative, { from = import.meta.url, env = process.env } = {}) {
+  let directory = startDirectory(from);
+  while (true) {
+    const found = packageFile(directory, relative);
+    if (found) return found;
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+
+  if (env.AKARI_MONOREPO) {
+    const found = packageFile(path.resolve(env.AKARI_MONOREPO), relative);
+    if (found) return found;
+  }
+
+  const installDirectory = env.AKARI_INSTALL_DIR
+    ? path.resolve(env.AKARI_INSTALL_DIR)
+    : path.join(homedir(), ".akari", "app");
+  if (existsSync(installDirectory)) {
+    const found = packageFile(installDirectory, relative);
+    if (found) return found;
+  }
+
+  throw new Error(SETUP_GUIDE);
+}
+
+export async function importPackage(relative, options) {
+  const absolutePath = resolvePackageFile(relative, options);
+  return import(pathToFileURL(absolutePath).href);
+}

--- a/skills/analyze-footage/bin/test/person-matte-availability.test.mjs
+++ b/skills/analyze-footage/bin/test/person-matte-availability.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  checkAvailability,
+  parseArguments,
+  prepareExecution,
+} from "../person-matte/person-matte.mjs";
+
+function successfulMediaProbe(command, args) {
+  if (command === "/mock/ffmpeg" && args.includes("-encoders")) {
+    return { status: 0, stdout: " V..... libvpx-vp9" };
+  }
+  return { status: 0, stdout: "" };
+}
+
+test("darwin availability requires a Vision helper source or built binary", () => {
+  const result = checkAvailability({
+    platform: "darwin",
+    fileExists: () => false,
+    runSync: () => assert.fail("missing helper must stop before probing tools"),
+    resolveFfmpegBin: () => assert.fail("missing helper must stop before resolving tools"),
+    resolveFfprobeBin: () => assert.fail("missing helper must stop before resolving tools"),
+  });
+  assert.equal(result.available, false);
+  assert.match(result.reason, /Vision.*ヘルパー/u);
+});
+
+test("win32 availability reports unavailable when the RVM resolver was not loaded", () => {
+  const result = checkAvailability({
+    platform: "win32",
+    runSync: successfulMediaProbe,
+    resolveFfmpegBin: () => "/mock/ffmpeg",
+    resolveFfprobeBin: () => "/mock/ffprobe",
+  });
+  assert.equal(result.available, false);
+  assert.match(result.reason, /RVM.*入っていない/u);
+});
+
+test("prepareExecution needs an RVM resolver only on an RVM engine", () => {
+  const vision = prepareExecution(parseArguments([]), {
+    platform: "darwin",
+    buildVisionHelper: () => null,
+  });
+  assert.equal(vision.engine, "vision");
+
+  assert.throws(
+    () => prepareExecution(parseArguments(["--quality", "best"]), { platform: "darwin" }),
+    /RVM.*入っていない/u,
+  );
+});

--- a/skills/analyze-footage/person-matte.md
+++ b/skills/analyze-footage/person-matte.md
@@ -8,6 +8,7 @@
 - [カットへ自動配線する](#カットへ自動配線する)
 - [analysis.json へ書く](#analysisjson-へ書く)
 - [グレースケールマスクを使う](#グレースケールマスクを使う)
+- [RVM の実行環境を入れる](#rvm-の実行環境を入れる)
 - [Windows 実機検証手順](#windows-実機検証手順)
 - [劣化](#劣化)
 
@@ -60,7 +61,7 @@ node "$PERSON_MATTE_BIN/person-matte.mjs" --check
 `available:true` 以外なら `reason` を報告し、マットを作らずに `null` のまま進む。結果には既定の
 RVM モデルの配備状況を示す `rvm_model` も含まれる。Mac は `swiftc`、同梱メディア道具、VP9 alpha
 エンコーダを要求する。Windows は swiftc を要求せず、同じメディア道具に加えて RVM の
-mobilenetv3 モデルを要求する。メディア道具の探索はサイドカー生成器内部の解決規則に委ねる。
+実行環境と mobilenetv3 モデルを要求する。メディア道具の探索はサイドカー生成器内部の解決規則に委ねる。
 ネットワークからツールを導入しない。Mac の Swift ヘルパーは初回実行時に `swiftc -O` で自動ビルドされ、
 バイナリはコミットしない（[.gitignore](.gitignore) 参照）。
 
@@ -183,6 +184,18 @@ node "$PERSON_MATTE_BIN/mask-roundtrip.mjs" --alpha <webm> --mask <mp4>
 alpha WebM を真値とみなす取り込み変換の基準である。併産された兄弟 2 形式の比較では、それぞれの
 符号化損失の和を測るため、この閾値で `ok:false` になっても変換精度の不合格を意味しない。
 
+## RVM の実行環境を入れる
+
+Windows で人物マットを作る場合と、Mac で `--quality best` を使う場合は、公開リポジトリのルートで
+次の 1 コマンドを実行する。`--check` の `rvm_runtime.available` が `false` のときも同じ手順で直せる。
+
+```bash
+cd packages/matte-rvm && npm install
+```
+
+モデルは別に配備する。実行環境を入れたあと、既定モデルは同じディレクトリで
+`npm run fetch:models` を実行して取得する。モデルをリポジトリへコミットしない。
+
 ## Windows 実機検証手順
 
 Windows では `fast` / `balanced` / `accurate` / `best` の全段が RVM mobilenetv3 を使う。
@@ -204,10 +217,11 @@ $PersonMatteBin = if (Test-Path ".claude\skills\analyze-footage\bin\person-matte
 node "$PersonMatteBin\person-matte.mjs" --check
 ```
 
-期待する 1 行 JSON は次の形で、`available` が `true`、`rvm_model.missing` が `false` になる。
+期待する 1 行 JSON は次の形で、`available` が `true`、`rvm_model.missing` が `false`、
+`rvm_runtime.available` が `true` になる。
 
 ```json
-{"available":true,"rvm_model":{"model":"mobilenetv3","path":"C:\\...\\rvm_mobilenetv3_fp32.onnx","missing":false,"fetchHint":"cd packages/matte-rvm && node scripts/fetch-models.mjs"}}
+{"available":true,"rvm_model":{"model":"mobilenetv3","path":"C:\\...\\rvm_mobilenetv3_fp32.onnx","missing":false,"fetchHint":"cd packages/matte-rvm && node scripts/fetch-models.mjs"},"rvm_runtime":{"available":true,"reason":null,"installHint":"cd packages/matte-rvm && npm install"}}
 ```
 
 次に、人物が映る実素材 1 本を `C:\Users\owner\Videos\person-input.mp4` へ置き、`balanced` で生成する。
@@ -238,6 +252,9 @@ node "$PersonMatteBin\person-matte.mjs" --input "$SOURCE" --out "$OUT" --quality
 - `elapsed_seconds`: ______ 秒
 
 つまずいた場合は `reason` を先に読む。
+
+- 実行環境不在: `rvm_runtime.available:false` を確認し、[RVM の実行環境を入れる](#rvm-の実行環境を入れる)
+  の 1 コマンドを実行してから再検査する。
 
 - モデル不在: `rvm_model.missing:true` または reason 内の `fetchHint` を確認し、次のコマンドで
   mobilenetv3 を取得してから再検査する。

--- a/skills/analyze-footage/person-matte.md
+++ b/skills/analyze-footage/person-matte.md
@@ -16,7 +16,7 @@
 人物マットは**人物演出（text-behind-person など）を使うと決めた素材でだけ**作る。既定の分析
 フローはマットを作らず `tracks.person_matte` に `null` を書く。データ契約は
 [docs/contract-2026-07-23-analysis-person-matte.md](../../docs/contract-2026-07-23-analysis-person-matte.md) が正本である。
-以下の `node bin/person-matte/...` は L3 サイドカー生成器の公開インターフェースであり、媒体バックエンドを
+以下の `$PERSON_MATTE_BIN/...` は L3 サイドカー生成器の公開インターフェースであり、媒体バックエンドを
 analyze-footage の手順から直接呼ぶものではない。内部のデコード・検証は生成器自身が担う。
 
 ## 実行するかを先に決める
@@ -52,7 +52,9 @@ Windows では全品質段が RVM mobilenetv3 になる。手順は [Windows 実
 ## 道具を確認する
 
 ```bash
-node bin/person-matte/person-matte.mjs --check
+PERSON_MATTE_BIN=".claude/skills/analyze-footage/bin/person-matte"
+[ -d "$PERSON_MATTE_BIN" ] || PERSON_MATTE_BIN="skills/analyze-footage/bin/person-matte"
+node "$PERSON_MATTE_BIN/person-matte.mjs" --check
 ```
 
 `available:true` 以外なら `reason` を報告し、マットを作らずに `null` のまま進む。結果には既定の
@@ -67,7 +69,7 @@ mobilenetv3 モデルを要求する。メディア道具の探索はサイド�
 出力は analysis.json と同じディレクトリの `matte/person-matte.webm` に置く。
 
 ```bash
-node bin/person-matte/person-matte.mjs \
+node "$PERSON_MATTE_BIN/person-matte.mjs" \
   --input "$SOURCE" \
   --out "$OUT_DIR/matte/person-matte.webm"
 ```
@@ -103,7 +105,7 @@ Vision 時の `vision_ms_per_frame` または RVM 時の `rvm_ms_per_frame`、
   `out` / `speed` を解決し、速度適用済みの区間マットを作って v2 `edit.json` へ自動配線する。
 
 ```bash
-node skills/analyze-footage/bin/person-matte/person-cutout.mjs \
+node "$PERSON_MATTE_BIN/person-cutout.mjs" \
   --project /path/to/project \
   --cut 0
 ```
@@ -126,7 +128,7 @@ atomic rename し、不合格時は元ファイルを変更しない。
 書き換えを一切行わず、予定するマット・レイヤー互換表示・track 順を stdout の 1 行 JSON で返す。
 
 ```bash
-node skills/analyze-footage/bin/person-matte/person-cutout.mjs \
+node "$PERSON_MATTE_BIN/person-cutout.mjs" \
   --project /path/to/project \
   --cut 1,3 \
   --quality best \
@@ -167,11 +169,17 @@ node skills/analyze-footage/bin/person-matte/person-cutout.mjs \
 あれば skip し、作り直す場合だけ `--force` を付ける。
 
 ```bash
-node bin/person-matte/mask-from-alpha.mjs \
+node "$PERSON_MATTE_BIN/mask-from-alpha.mjs" \
   --input "$OUT_DIR/matte/person-matte.webm"
 ```
 
-往復精度は `mask-roundtrip.mjs --alpha <webm> --mask <mp4>` で全フレーム比較できる。合否閾値は
+往復精度は次のコマンドで全フレーム比較できる。
+
+```bash
+node "$PERSON_MATTE_BIN/mask-roundtrip.mjs" --alpha <webm> --mask <mp4>
+```
+
+合否閾値は
 alpha WebM を真値とみなす取り込み変換の基準である。併産された兄弟 2 形式の比較では、それぞれの
 符号化損失の和を測るため、この閾値で `ok:false` になっても変換精度の不合格を意味しない。
 
@@ -179,20 +187,21 @@ alpha WebM を真値とみなす取り込み変換の基準である。併産さ
 
 Windows では `fast` / `balanced` / `accurate` / `best` の全段が RVM mobilenetv3 を使う。
 次の PowerShell コマンドは公開リポジトリのルートで実行する。Node.js 20 以上を前提とし、まず版を確認して
-`packages/matte-rvm` 内で依存と既定モデルを配備する。`npm install` の postinstall が
-mobilenetv3 を取得する。
+`packages/matte-rvm` 内で依存と既定モデルを明示的に配備する。
 
 ```powershell
 node --version
 cd packages\matte-rvm
 npm install
+npm run fetch:models
 cd ..\..
+$PersonMatteBin = if (Test-Path ".claude\skills\analyze-footage\bin\person-matte") { ".claude\skills\analyze-footage\bin\person-matte" } else { "skills\analyze-footage\bin\person-matte" }
 ```
 
 道具とモデルを検査する。
 
 ```powershell
-node skills\analyze-footage\bin\person-matte\person-matte.mjs --check
+node "$PersonMatteBin\person-matte.mjs" --check
 ```
 
 期待する 1 行 JSON は次の形で、`available` が `true`、`rvm_model.missing` が `false` になる。
@@ -207,7 +216,7 @@ node skills\analyze-footage\bin\person-matte\person-matte.mjs --check
 ```powershell
 $SOURCE = "C:\Users\owner\Videos\person-input.mp4"
 $OUT = "C:\Users\owner\Videos\person-matte-balanced.webm"
-node skills\analyze-footage\bin\person-matte\person-matte.mjs --input "$SOURCE" --out "$OUT" --quality balanced
+node "$PersonMatteBin\person-matte.mjs" --input "$SOURCE" --out "$OUT" --quality balanced
 ```
 
 実際に返る 1 行 JSON から確認するキーの抜粋は次のとおりで、`ok:true`、`engine:"rvm"`、`model:"mobilenetv3"`、
@@ -237,7 +246,7 @@ node skills\analyze-footage\bin\person-matte\person-matte.mjs --input "$SOURCE" 
   cd packages\matte-rvm
   node scripts\fetch-models.mjs
   cd ..\..
-  node skills\analyze-footage\bin\person-matte\person-matte.mjs --check
+  node "$PersonMatteBin\person-matte.mjs" --check
   ```
 
 - 同梱メディア道具不在: `packages/media-bin` の postinstall が同梱バイナリを配備するため、
@@ -247,7 +256,7 @@ node skills\analyze-footage\bin\person-matte\person-matte.mjs --input "$SOURCE" 
   cd packages\media-bin
   npm install
   cd ..\..
-  node skills\analyze-footage\bin\person-matte\person-matte.mjs --check
+  node "$PersonMatteBin\person-matte.mjs" --check
   ```
 
 - `libvpx-vp9` 不在: 解決された encoder が VP9 alpha を書けない。`reason` に従って media-bin の配備と

--- a/skills/manage-connections/SKILL.md
+++ b/skills/manage-connections/SKILL.md
@@ -77,3 +77,4 @@ doctor は connections.json の `doctor` ブロックを書き戻し、プロジ
 - first-run・代理取得しない規律: [../setup-library/SKILL.md](../setup-library/SKILL.md)
 - 有償操作の承認ゲート: [../edit-plan/approvals-and-generation.md](../edit-plan/approvals-and-generation.md)
 - レジストリ検証: `node packages/schemas/bin/validate-connections.mjs .akari/connections.json`
+  （モノレポでのみ実行可。プロジェクト配布版には同梱されていない）

--- a/skills/manage-connections/bin/doctor.mjs
+++ b/skills/manage-connections/bin/doctor.mjs
@@ -5,9 +5,21 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-import { DEFAULT_CONNECTIONS_REGISTRY } from "../../../packages/creator-root/src/index.mjs";
-import { resolveConnections } from "./resolve-connections.mjs";
+import { importPackage } from "./resolve-packages.mjs";
+
+let DEFAULT_CONNECTIONS_REGISTRY;
+let resolveConnections;
+
+async function loadDependencies() {
+  const [creatorRoot, connections] = await Promise.all([
+    importPackage("creator-root/src/index.mjs", { from: import.meta.url }),
+    import("./resolve-connections.mjs"),
+  ]);
+  DEFAULT_CONNECTIONS_REGISTRY = creatorRoot.DEFAULT_CONNECTIONS_REGISTRY;
+  resolveConnections = connections.resolveConnections;
+}
 
 const usage = "使い方: node skills/manage-connections/bin/doctor.mjs [プロジェクトルート|connections.json]";
 const argument = process.argv[2];
@@ -36,6 +48,7 @@ const credentialsPath = path.resolve(
 const timeoutMs = 5_000;
 
 async function main() {
+  await loadDependencies();
   if (inputPath.endsWith(".json")) {
     await mainLegacy();
     return;
@@ -446,7 +459,18 @@ function isPlainObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-main().catch(() => {
-  console.error("接続確認を完了できませんでした。connections.json の形式と書き込み権限を確認してください。");
-  process.exitCode = 1;
-});
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try {
+    return fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(path.resolve(process.argv[1]));
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(error?.message ?? "接続確認を完了できませんでした。connections.json の形式と書き込み権限を確認してください。");
+    process.exit(1);
+  });
+}

--- a/skills/manage-connections/bin/resolve-connections.mjs
+++ b/skills/manage-connections/bin/resolve-connections.mjs
@@ -1,13 +1,21 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import {
-    DEFAULT_CONNECTIONS_REGISTRY,
-    resolveCreatorRoot
-} from '../../../packages/creator-root/src/index.mjs';
+import { importPackage } from './resolve-packages.mjs';
+
+let DEFAULT_CONNECTIONS_REGISTRY;
+let resolveCreatorRoot;
+
+async function loadCreatorRoot() {
+    if (resolveCreatorRoot) return;
+    const creatorRoot = await importPackage('creator-root/src/index.mjs', { from: import.meta.url });
+    DEFAULT_CONNECTIONS_REGISTRY = creatorRoot.DEFAULT_CONNECTIONS_REGISTRY;
+    resolveCreatorRoot = creatorRoot.resolveCreatorRoot;
+}
 
 const PROVIDER_KINDS = new Set(['genai', 'image', 'video', 'tts', 'music', 'sns', 'analytics']);
 const PROVIDER_AUTHS = new Set(['login', 'env-key', 'oauth-mcp', 'none']);
@@ -99,6 +107,7 @@ export async function resolveConnections({
     env = process.env,
     platform = process.platform
 } = {}) {
+    await loadCreatorRoot();
     const resolvedProjectRoot = path.resolve(projectRoot);
     const projectPath = path.join(resolvedProjectRoot, '.akari', 'connections.json');
     const project = await readConnectionsFile(projectPath);
@@ -342,7 +351,21 @@ function clone(value) {
     return JSON.parse(JSON.stringify(value));
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
-    const resolved = await resolveConnections({ projectRoot: process.argv[2] ?? process.cwd() });
-    process.stdout.write(`${JSON.stringify(resolved, null, 2)}\n`);
+function isMainModule() {
+    if (!process.argv[1]) return false;
+    try {
+        return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(path.resolve(process.argv[1]));
+    } catch {
+        return false;
+    }
+}
+
+if (isMainModule()) {
+    try {
+        const resolved = await resolveConnections({ projectRoot: process.argv[2] ?? process.cwd() });
+        process.stdout.write(`${JSON.stringify(resolved, null, 2)}\n`);
+    } catch (error) {
+        console.error(error?.message ?? '接続設定を解決できませんでした。');
+        process.exit(1);
+    }
 }

--- a/skills/manage-connections/bin/resolve-packages.mjs
+++ b/skills/manage-connections/bin/resolve-packages.mjs
@@ -1,0 +1,58 @@
+import { existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SETUP_GUIDE = "セットアップするには次を実行してください: curl -fsSL https://raw.githubusercontent.com/AkariLabs/akari-video/main/install.sh | bash";
+
+function startDirectory(from) {
+  const value = from instanceof URL || String(from).startsWith("file:")
+    ? fileURLToPath(from)
+    : path.resolve(String(from));
+  try {
+    if (statSync(value).isDirectory()) return value;
+  } catch {
+    // 存在しないファイル位置も呼び出し元として扱えるよう、親から探索する。
+  }
+  return path.dirname(value);
+}
+
+function packageFile(root, relative) {
+  const candidate = path.resolve(root, "packages", relative);
+  try {
+    return statSync(candidate).isFile() ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolvePackageFile(relative, { from = import.meta.url, env = process.env } = {}) {
+  let directory = startDirectory(from);
+  while (true) {
+    const found = packageFile(directory, relative);
+    if (found) return found;
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+
+  if (env.AKARI_MONOREPO) {
+    const found = packageFile(path.resolve(env.AKARI_MONOREPO), relative);
+    if (found) return found;
+  }
+
+  const installDirectory = env.AKARI_INSTALL_DIR
+    ? path.resolve(env.AKARI_INSTALL_DIR)
+    : path.join(homedir(), ".akari", "app");
+  if (existsSync(installDirectory)) {
+    const found = packageFile(installDirectory, relative);
+    if (found) return found;
+  }
+
+  throw new Error(SETUP_GUIDE);
+}
+
+export async function importPackage(relative, options) {
+  const absolutePath = resolvePackageFile(relative, options);
+  return import(pathToFileURL(absolutePath).href);
+}

--- a/skills/manage-connections/bin/test/resolve-packages.test.mjs
+++ b/skills/manage-connections/bin/test/resolve-packages.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { importPackage, resolvePackageFile } from "../resolve-packages.mjs";
+
+async function withScratch(run) {
+  const scratch = await mkdtemp(path.join(tmpdir(), "akari-resolve-packages-"));
+  try {
+    await run(scratch);
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+}
+
+async function addPackageFile(root, relative, source = "export const marker = 'ok';\n") {
+  const file = path.join(root, "packages", relative);
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, source, "utf8");
+  return file;
+}
+
+test("resolvePackageFile は呼び出し元から上方探索する", async () => {
+  await withScratch(async (scratch) => {
+    const expected = await addPackageFile(scratch, "sample/src/index.mjs");
+    const from = pathToFileURL(path.join(scratch, "skills", "sample", "bin", "entry.mjs")).href;
+    assert.equal(
+      resolvePackageFile("sample/src/index.mjs", { from, env: {} }),
+      expected,
+    );
+  });
+});
+
+test("resolvePackageFile は AKARI_MONOREPO を使う", async () => {
+  await withScratch(async (scratch) => {
+    const root = path.join(scratch, "monorepo-root");
+    const expected = await addPackageFile(root, "sample/src/index.mjs");
+    assert.equal(
+      resolvePackageFile("sample/src/index.mjs", {
+        from: path.join(scratch, "project", ".claude", "skills", "sample", "bin", "entry.mjs"),
+        env: { AKARI_MONOREPO: root, AKARI_INSTALL_DIR: path.join(scratch, "unused") },
+      }),
+      expected,
+    );
+  });
+});
+
+test("resolvePackageFile は AKARI_INSTALL_DIR を使う", async () => {
+  await withScratch(async (scratch) => {
+    const root = path.join(scratch, "installed-app");
+    const expected = await addPackageFile(root, "sample/src/index.mjs");
+    assert.equal(
+      resolvePackageFile("sample/src/index.mjs", {
+        from: path.join(scratch, "project", ".claude", "skills", "sample", "bin", "entry.mjs"),
+        env: { AKARI_INSTALL_DIR: root },
+      }),
+      expected,
+    );
+  });
+});
+
+test("見つからない場合は専門語のないセットアップ案内 1 行で失敗する", async () => {
+  await withScratch(async (scratch) => {
+    assert.throws(
+      () => resolvePackageFile("missing/src/index.mjs", {
+        from: path.join(scratch, "project", "entry.mjs"),
+        env: { AKARI_INSTALL_DIR: path.join(scratch, "unused") },
+      }),
+      (error) => {
+        assert.equal(
+          error.message,
+          "セットアップするには次を実行してください: curl -fsSL https://raw.githubusercontent.com/AkariLabs/akari-video/main/install.sh | bash",
+        );
+        assert.equal(error.message.split(/\r?\n/u).length, 1);
+        assert.doesNotMatch(error.message, /ERR_MODULE_NOT_FOUND|monorepo|import/iu);
+        return true;
+      },
+    );
+  });
+});
+
+test("importPackage は絶対パスを file URL にして読み込む", async () => {
+  await withScratch(async (scratch) => {
+    const root = path.join(scratch, "root with spaces");
+    await addPackageFile(root, "sample/src/index.mjs", "export const marker = 'loaded';\n");
+    const loaded = await importPackage("sample/src/index.mjs", {
+      from: path.join(scratch, "outside", "entry.mjs"),
+      env: { AKARI_MONOREPO: root, AKARI_INSTALL_DIR: path.join(scratch, "unused") },
+    });
+    assert.equal(loaded.marker, "loaded");
+  });
+});
+
+test("3 スキルの resolve-packages.mjs は同一内容", async () => {
+  const current = fileURLToPath(new URL("../resolve-packages.mjs", import.meta.url));
+  const root = path.resolve(path.dirname(current), "..", "..");
+  const copies = [
+    path.join(root, "setup-chat-approval", "bin", "resolve-packages.mjs"),
+    path.join(root, "analyze-footage", "bin", "person-matte", "resolve-packages.mjs"),
+  ];
+  const expected = await readFile(current, "utf8");
+  for (const copy of copies) assert.equal(await readFile(copy, "utf8"), expected);
+});

--- a/skills/setup-chat-approval/bin/doctor.mjs
+++ b/skills/setup-chat-approval/bin/doctor.mjs
@@ -3,16 +3,25 @@
 // トークンの値は絶対に出力しない（有無と長さの妥当性だけを見る）。
 // 契約: docs/contract-2026-08-12-chat-approval-v0.md
 
+import { realpathSync } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-import {
-  CHAT_ENV_KEY,
-  TOKEN_ENV_KEY,
-  parseCredentials,
-} from "../../../packages/chat-bridge/src/telegram-core.mjs";
+import { importPackage } from "./resolve-packages.mjs";
+
+let CHAT_ENV_KEY;
+let TOKEN_ENV_KEY;
+let parseCredentials;
+
+async function loadDependencies() {
+  const telegram = await importPackage("chat-bridge/src/telegram-core.mjs", { from: import.meta.url });
+  CHAT_ENV_KEY = telegram.CHAT_ENV_KEY;
+  TOKEN_ENV_KEY = telegram.TOKEN_ENV_KEY;
+  parseCredentials = telegram.parseCredentials;
+}
 
 const PROVIDER_ID = "telegram-approval";
 
@@ -103,6 +112,7 @@ function decideState(credentials, registry) {
 }
 
 async function main() {
+  await loadDependencies();
   const projectRoot = path.resolve(process.argv[2] ?? process.cwd());
   const credentials = await inspectCredentials();
   const registry = await inspectRegistry(projectRoot);
@@ -126,7 +136,18 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exit(1);
-});
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(path.resolve(process.argv[1]));
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(error?.message ?? "Telegram の接続状態を確認できませんでした。");
+    process.exit(1);
+  });
+}

--- a/skills/setup-chat-approval/bin/find-chat-id.mjs
+++ b/skills/setup-chat-approval/bin/find-chat-id.mjs
@@ -3,14 +3,26 @@
 // 読み取り専用（getUpdates のみ・無償）。credentials.env へは書き戻さない（人間が書く）。
 // トークンは出力に出さない。
 
+import { realpathSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-import { parseCredentials, redactToken } from "../../../packages/chat-bridge/src/telegram-core.mjs";
+import { importPackage } from "./resolve-packages.mjs";
+
+let parseCredentials;
+let redactToken;
+
+async function loadDependencies() {
+  const telegram = await importPackage("chat-bridge/src/telegram-core.mjs", { from: import.meta.url });
+  parseCredentials = telegram.parseCredentials;
+  redactToken = telegram.redactToken;
+}
 
 async function main() {
+  await loadDependencies();
   const filePath =
     process.env.AKARI_CREDENTIALS_FILE ??
     path.join(homedir(), ".config", "akari-video", "credentials.env");
@@ -62,7 +74,18 @@ async function main() {
   );
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exit(1);
-});
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(path.resolve(process.argv[1]));
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(error?.message ?? "Telegram の chat ID を確認できませんでした。");
+    process.exit(1);
+  });
+}

--- a/skills/setup-chat-approval/bin/resolve-packages.mjs
+++ b/skills/setup-chat-approval/bin/resolve-packages.mjs
@@ -1,0 +1,58 @@
+import { existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SETUP_GUIDE = "セットアップするには次を実行してください: curl -fsSL https://raw.githubusercontent.com/AkariLabs/akari-video/main/install.sh | bash";
+
+function startDirectory(from) {
+  const value = from instanceof URL || String(from).startsWith("file:")
+    ? fileURLToPath(from)
+    : path.resolve(String(from));
+  try {
+    if (statSync(value).isDirectory()) return value;
+  } catch {
+    // 存在しないファイル位置も呼び出し元として扱えるよう、親から探索する。
+  }
+  return path.dirname(value);
+}
+
+function packageFile(root, relative) {
+  const candidate = path.resolve(root, "packages", relative);
+  try {
+    return statSync(candidate).isFile() ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolvePackageFile(relative, { from = import.meta.url, env = process.env } = {}) {
+  let directory = startDirectory(from);
+  while (true) {
+    const found = packageFile(directory, relative);
+    if (found) return found;
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+
+  if (env.AKARI_MONOREPO) {
+    const found = packageFile(path.resolve(env.AKARI_MONOREPO), relative);
+    if (found) return found;
+  }
+
+  const installDirectory = env.AKARI_INSTALL_DIR
+    ? path.resolve(env.AKARI_INSTALL_DIR)
+    : path.join(homedir(), ".akari", "app");
+  if (existsSync(installDirectory)) {
+    const found = packageFile(installDirectory, relative);
+    if (found) return found;
+  }
+
+  throw new Error(SETUP_GUIDE);
+}
+
+export async function importPackage(relative, options) {
+  const absolutePath = resolvePackageFile(relative, options);
+  return import(pathToFileURL(absolutePath).href);
+}

--- a/skills/setup-chat-approval/setup-token.md
+++ b/skills/setup-chat-approval/setup-token.md
@@ -3,7 +3,9 @@
 ## 1. doctor を実行する
 
 ```
-node skills/setup-chat-approval/bin/doctor.mjs [プロジェクトルート]
+SETUP_CHAT_SKILL=".claude/skills/setup-chat-approval"
+[ -d "$SETUP_CHAT_SKILL" ] || SETUP_CHAT_SKILL="skills/setup-chat-approval"
+node "$SETUP_CHAT_SKILL/bin/doctor.mjs" [プロジェクトルート]
 ```
 
 読み取り専用・無償・ネットワークを使わない。**トークンの値は出力されない**（有無と形の妥当性だけ）。
@@ -44,7 +46,7 @@ AKARI_TELEGRAM_BOT_TOKEN=<BotFather が出した値>
 1. ユーザーに、作った bot を Telegram で開いて `/start` か任意の一言を送ってもらう
 2. 次を実行する（`getUpdates` のみ・無償・読み取り専用）:
    ```
-   node skills/setup-chat-approval/bin/find-chat-id.mjs
+   node "$SETUP_CHAT_SKILL/bin/find-chat-id.mjs"
    ```
 3. 表示された ID を、ユーザー自身に追記してもらう:
    ```
@@ -62,6 +64,8 @@ AKARI_TELEGRAM_BOT_TOKEN=<BotFather が出した値>
 [`packages/schemas/examples/connections-v0-notify-valid/connections.json`](../../packages/schemas/examples/connections-v0-notify-valid/connections.json)。
 
 登録後、スキーマ検証で形を確かめる:
+
+次の検証器はモノレポでのみ実行可（プロジェクト配布版には同梱されていない）。
 
 ```
 node packages/schemas/bin/validate-connections.mjs <プロジェクト>/.akari/connections.json


### PR DESCRIPTION
新規 Mac での実機報告「接続まわりのスクリプトが参照する `.claude/packages/` が無い」「セットアップで matte-rvm が使えないと出る」「初回からリンクを貼っても動かないスクリプトとして出てしまう」を起点に、3 つの票を積んだブランチです。

## 何が起きていたか

スキルは 3 つの場所へ配られますが、`packages/` が付いてくるのはモノレポだけでした。

| 配置 | `packages/` |
|---|---|
| モノレポ | あり |
| プロジェクト配布版（`installProjectSkills()` が `.claude/skills/` へ実体コピー） | **無し** |
| アプリ同梱版（`Resources/skills/...`） | 一部のみ |

スクリプト側の import はモノレポ前提の固定相対パス（`../../../packages/...`）だったため、プロジェクト配布版では必ず `ERR_MODULE_NOT_FOUND` になります。

```
$ node .claude/skills/manage-connections/bin/doctor.mjs
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  '.../project/.claude/packages/creator-root/src/index.mjs'
```

## この PR の中身

### 1. 解決規則を一本化（`task/2026-09-03-skill-package-resolution`）

`resolve-packages.mjs` を新設し、探索順を `akari.sh` の `find_monorepo()` と揃えました。

1. 自身の位置から上へ辿って `packages/` を持つ根を探す
2. `AKARI_MONOREPO`
3. `${AKARI_INSTALL_DIR:-~/.akari/app}`

モノレポとアプリ同梱 `Resources/` はどちらも `<root>/packages/` と `<root>/skills/` を並べた形なので、1 の規則だけで両方当たります。根が見つからないときは専門語を出さず、セットアップ 1 行コマンドを案内して終わります。

あわせて同梱漏れを 3 件塞ぎました。

- `packages/chat-bridge` が `extraResources` に無い（setup-chat-approval が同梱版で死ぬ）
- `packages/schemas` の filter に `bin/validate-edit.mjs` が無い
- person-matte の filter が `*.mjs` のみで **`person-matte-helper.swift` が同梱されない** → 同梱版では Vision 経路もビルド不能。しかも `--check` は `available: true` と嘘をついていた

macOS を RVM から切り離し、`packages/matte-rvm` の `postinstall` を明示実行（`fetch:models`）へ、`onnxruntime-node` を `optionalDependencies` へ移しました。

### 2. GPL 資産の再配布を機械で禁止（`task/2026-09-03-rvm-redistribution-guard`）

upstream PeterL1n/RobustVideoMatting の LICENSE は **GPL-3.0** ですが、`NOTICE.md` は `Robust Video Matting is MIT licensed.` と記載していました。本プロダクトは MIT 配布です。

- `NOTICE.md` を事実に合わせて訂正（GPL-3.0 である旨・コードも重みも配布しない旨）
- `scripts/release/check-no-gpl-redistribution.mjs` を新設。`extraResources` / `build.files` / `build.extraFiles` / `git ls-files` / npm の `files` を fail-closed で検査。禁止リストは `RESTRICTED_ASSETS` 1 箇所の宣言から導く
- CI の required 配布ゲートへ相乗り

### 3. 行き止まりの撤去とガードの網（`task/2026-09-04-rvm-runtime-deadend`）

`rvm-helper.mjs` の `onnxruntime-node` は静的 import で、不在時は **17 行のスタックトレース + 90 秒ハング**でした。Windows は `engineForPlatform()` により全品質段が RVM 依存なので、Windows 利用者が踏む経路です。

- ランタイム解決を `resolveRvmRuntime()` として追加し、モデル不在（`fetchHint`）と同じ形式・同じ調子の案内に揃えた
- 動的解決化によって `check-packaged-imports.mjs` が追えなくなった skills → `packages/` 参照を、解決関数の**文字列リテラル引数のときだけ**拾う走査として復活。意図的に同梱しない `matte-rvm` は `RESTRICTED_ASSETS` を共有して除外し、除外したことを出力に明示

## 検証（実測）

```
# ① ガードの網
実ツリー          exit 0（matte-rvm を「除外した」2 件として行番号付きで明示）
chat-bridge 欠落  exit 1（PACKAGE RESOLVER MISSING 2・telegram-core.mjs を名指し）
media-bin 欠落    exit 1（MISSING 16）
edit-store 欠落   exit 1（MISSING 3）
schemas 欠落      exit 1（MISSING 1）
creator-root 欠落 exit 1

# ③ ランタイム不在（モデルは在る状態）
--check         → {"rvm_runtime":{"available":false,
                   "reason":"RVM の実行環境が入っていないため、この品質では人物マットを生成できません",
                   "installHint":"cd packages/matte-rvm && npm install"}}
                  exit 0 / stderr 0 行
--quality best  → 1 行 JSON で停止  exit 1 / 経過 1 秒 / stderr 0 行
                  （BEFORE: 17 行スタックトレース + 90 秒ハング）

# macOS 既定（Vision / balanced）非退行 — 実際に 1 本生成
{"ok":true,"engine":"vision","quality":"balanced"}
codec_name=vp9  width=1280  height=720  r_frame_rate=24/1  TAG:alpha_mode=1

# 同梱版 import グラフ
check-packaged-imports: OK（欠け 0）
  ※ 修正前の main に skills 入口だけを足すと
    MISSING 1: packages/matte-rvm/src/index.mjs <- person-matte.mjs

# 再配布禁止ガード
check-no-gpl-redistribution: OK（restricted 1 件 / 違反 0）
  メタテスト 6 種（オブジェクト形式 / 文字列形式 / build.files / extraFiles /
  packages 丸ごと / vendor の .onnx を git 追跡下）すべて非ゼロ終了
```

`test:shell` 2079/2079 pass。`test:unit` は 1556 pass / fail 1（`packages/asset-resolver` の `/private/var` realpath 差で、分岐点の main で既に赤。本 PR の退行ではありません）。

## 積み残し

- **人物マットの代替エンジンは未定**。GPL-3.0 の RVM から Apache-2.0 候補（MediaPipe Selfie / PP-HumanSegV2-Lite / MODNet 公式）への差し替えを較正しましたが、**現時点で Windows の既定として無条件に推せる候補はありません**。第一候補の PP-HumanSegV2-Lite general は対 Vision IoU が候補中最高（0.9507 / 0.9766）ですが背景ちらつきが RVM の 29〜60 倍。MODNet は髪が最良ですが 992〜1,740 ms/frame。よって RVM は当面 opt-in・非同梱のまま
- 較正は上半身 2 クリップ・macOS arm64 CPU EP のみ。**全身・四肢分離の実写素材が未測定**
- `install.sh` の PATH 設計（portable Node を `~/.akari/runtime/` へ置くが shell rc には `~/.akari/app` しか通していない）は別票
- スキル md の `node packages/...` 表記（約 60 箇所・cwd がモノレポ根である前提）は、本 PR で挙動を変えたスキルの分だけ修正済み。残りは別途

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrnU11PpnAMQeqo5GAaNr2
