### PR TITLE
[修正] 3D 宣言を含む断片の CSS アニメをタイムラインへ同期する

### DIFF
--- a/apps/shell/extensions/akari-preview/test/caption-entry-animation-hit-region.test.mjs
+++ b/apps/shell/extensions/akari-preview/test/caption-entry-animation-hit-region.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -29,7 +29,9 @@ function captionEntryAnimationsSettled(animations) {
 function loadPuppeteer() {
     const roots = [resolve(repositoryRoot, 'packages/render-cut')];
     const gitFile = resolve(repositoryRoot, '.git');
-    if (existsSync(gitFile)) {
+    // .git は git worktree では「gitdir: ...」を書いたファイル、通常の clone では
+  // ディレクトリ。existsSync だけで通すと clone 側で readFileSync が EISDIR で落ちる。
+  if (existsSync(gitFile) && statSync(gitFile).isFile()) {
         const gitDir = readFileSync(gitFile, 'utf8').trim().replace(/^gitdir:\s*/, '');
         const marker = `${join('.git', 'worktrees')}/`;
         const markerIndex = gitDir.indexOf(marker);

--- a/apps/shell/scripts/resign-electron.mjs
+++ b/apps/shell/scripts/resign-electron.mjs
@@ -15,22 +15,49 @@
 
 import { existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const TAG = '[resign-electron]';
 const shellRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const electronAppPath = path.join(shellRoot, 'node_modules', 'electron', 'dist', 'Electron.app');
+
+// electron は npm workspaces が monorepo ルートの node_modules へ hoist するため、
+// apps/shell/node_modules/electron は通常存在しない。shellRoot 固定でパスを組むと
+// hoist 先を見逃して「未インストール」と誤判定し、黙ってスキップする。すると
+// @theia/ffmpeg に署名を壊された .app がそのまま残り、Apple Silicon では
+// 「Electron main: loading modules...」の直後に無言で kill される（このファイル冒頭の
+// 注記そのものの症状。2026-09-04 に npm ci 済みの clone で実測）。
+// require.resolve は shellRoot から node_modules を遡るので、ネスト配置と hoist の
+// どちらでも当たる。electron の package.json に exports が無いのでサブパス解決も通る。
+const requireFromShell = createRequire(import.meta.url);
+function resolveElectronAppPath() {
+  try {
+    const packageJsonPath = requireFromShell.resolve('electron/package.json', { paths: [shellRoot] });
+    return path.join(path.dirname(packageJsonPath), 'dist', 'Electron.app');
+  } catch {
+    return null;
+  }
+}
+const electronAppPath = resolveElectronAppPath();
 
 if (process.platform !== 'darwin') {
   console.log(`${TAG} platform=${process.platform}: darwin 専用のステップのため no-op`);
   process.exit(0);
 }
 
+if (!electronAppPath) {
+  console.log(
+    `${TAG} electron パッケージを ${path.relative(process.cwd(), shellRoot)} から解決できません` +
+    '（electron devDependency 未インストールの可能性）— スキップ'
+  );
+  process.exit(0);
+}
+
 if (!existsSync(electronAppPath)) {
   console.log(
-    `${TAG} ${path.relative(shellRoot, electronAppPath)} が見つかりません` +
-    '（electron devDependency 未インストールの可能性）— スキップ'
+    `${TAG} ${path.relative(process.cwd(), electronAppPath)} が見つかりません` +
+    '（electron のバイナリ取得前の可能性）— スキップ'
   );
   process.exit(0);
 }
@@ -55,6 +82,6 @@ if (result.status !== 0) {
 }
 
 console.log(
-  `${TAG} OK — ${path.relative(shellRoot, electronAppPath)} をアドホック再署名しました` +
+  `${TAG} OK — ${path.relative(process.cwd(), electronAppPath)} をアドホック再署名しました` +
   '（@theia/ffmpeg の libffmpeg 差し替えで壊れた署名の自己修復 / 開発ビルド専用）'
 );

--- a/packages/overlay-runtime/src/overlay-runtime.js
+++ b/packages/overlay-runtime/src/overlay-runtime.js
@@ -279,6 +279,33 @@ function createOverlayRuntime(options = {}) {
         overlay.container.style.setProperty("--rotate", overlay.isBackground ? "0deg" : `${state.rotate}deg`);
         overlay.container.style.setProperty("opacity", String(state.opacity));
       }
+      // getAnimations({ subtree: true }) のコストは「ドキュメント全体に現存する CSS animation の
+      // 総数」にほぼ比例する（上の注記）。断片のアニメは `[data-akari-active]` ゲートで宣言する
+      // 規約なので、可視の間は顔ぶれが変わらない。毎 tick 引き直さず、可視化フリップ直後の
+      // tick と 250ms ごとだけ引き直す（遅れて生える animation も拾える。app.js と同じ）。
+      // Animation オブジェクトはライブなので、キャッシュ済みでも pause / currentTime の書き込みと
+      // 下の entryAnimationsSettled() の読み取りは現在値で動く。
+      //
+      // 3D 断片も必ずここを通す。three のシーンは three 側が時刻を持つ（mixer.setTime）が、
+      // 断片の **CSS** アニメを進めるのは誰の仕事でもなくなる。以前は 3D 分岐がこの手前で
+      // continue していたため、3D 宣言を含む断片の CSS アニメが 1 本も同期されず、壁時計で
+      // 走り切って animation-fill-mode の最終姿勢に張り付いていた（実機報告 2026-09-04:
+      // S4 の 3D ステージが画面中央に残り続ける。仕様は translate3d(142%) = 局所 7 秒まで画面外）。
+      // 書き出し（render-cut の rasterize.mjs）は __akariSyncAnimations を 3D コンテナにも
+      // 等しく掛けているので、ここで飛ばすとプレビューと書き出しで絵が食い違う。
+      const nowMs = performance.now();
+      if (
+        overlay.animations === undefined ||
+        nowMs - overlay.animationsAt > ANIMATIONS_CACHE_MS
+      ) {
+        overlay.animations = overlay.container.getAnimations({ subtree: true });
+        overlay.animationsAt = nowMs;
+      }
+      const animations = overlay.animations;
+      for (const animation of animations) {
+        animation.pause();
+        animation.currentTime = localTimeMs;
+      }
       if (overlay.isThreeDimensional) {
         // syncVideos: ライブプレビューでは動画テクスチャの時刻を誰も進めないので、
         // ここで overlay のローカル時刻へ合わせる（書き出しは rasterize が自前で
@@ -298,32 +325,13 @@ function createOverlayRuntime(options = {}) {
         if (overlay.hitPolicyPending) {
           window.akari.interaction?.syncOverlayHitRegion?.(overlay.container);
           window.akari.interaction?.applyOverlayHitPolicy?.(overlay.container);
-          if (entryAnimationsSettled(overlay.container.getAnimations({ subtree: true }))) {
+          if (entryAnimationsSettled(animations)) {
             window.akari.interaction?.invalidateOverlayHitPolicy?.(overlay.container);
             window.akari.interaction?.applyOverlayHitPolicy?.(overlay.container);
             overlay.hitPolicyPending = false;
           }
         }
         continue;
-      }
-      // getAnimations({ subtree: true }) のコストは「ドキュメント全体に現存する CSS animation の
-      // 総数」にほぼ比例する（上の注記）。断片のアニメは `[data-akari-active]` ゲートで宣言する
-      // 規約なので、可視の間は顔ぶれが変わらない。毎 tick 引き直さず、可視化フリップ直後の
-      // tick と 250ms ごとだけ引き直す（遅れて生える animation も拾える。app.js と同じ）。
-      // Animation オブジェクトはライブなので、キャッシュ済みでも pause / currentTime の書き込みと
-      // 下の entryAnimationsSettled() の読み取りは現在値で動く。
-      const nowMs = performance.now();
-      if (
-        overlay.animations === undefined ||
-        nowMs - overlay.animationsAt > ANIMATIONS_CACHE_MS
-      ) {
-        overlay.animations = overlay.container.getAnimations({ subtree: true });
-        overlay.animationsAt = nowMs;
-      }
-      const animations = overlay.animations;
-      for (const animation of animations) {
-        animation.pause();
-        animation.currentTime = localTimeMs;
       }
       // opacity と clip-path は現在時刻へ合わせ、可視な間は入場アニメの終了まで毎 tick
       // 測り直す。フリップ時だけでは通常再生の localTimeMs がほぼ 0 となり、0% 姿勢の

--- a/packages/overlay-runtime/test-harness/entry-animation-hit-region.test.mjs
+++ b/packages/overlay-runtime/test-harness/entry-animation-hit-region.test.mjs
@@ -2,14 +2,7 @@
 // pointer-events 規約だけでクリック可能なことを headless Chrome の実クリックで防ぐ。
 // 実行: node --test packages/overlay-runtime/test-harness/entry-animation-hit-region.test.mjs
 import assert from "node:assert/strict";
-import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -24,7 +17,9 @@ const HEIGHT = 1920;
 function loadPuppeteer() {
   const roots = [resolve(HERE, "../../render-cut")];
   const gitFile = resolve(HERE, "../../../.git");
-  if (existsSync(gitFile)) {
+  // .git は git worktree では「gitdir: ...」を書いたファイル、通常の clone では
+  // ディレクトリ。existsSync だけで通すと clone 側で readFileSync が EISDIR で落ちる。
+  if (existsSync(gitFile) && statSync(gitFile).isFile()) {
     const gitDir = readFileSync(gitFile, "utf8").trim().replace(/^gitdir:\s*/, "");
     const marker = `${join(".git", "worktrees")}/`;
     const markerIndex = gitDir.indexOf(marker);

--- a/packages/overlay-runtime/test-harness/full-frame-background-clip.test.mjs
+++ b/packages/overlay-runtime/test-harness/full-frame-background-clip.test.mjs
@@ -2,14 +2,7 @@
 // 回帰を headless Chrome の実描画ピクセルで防ぐ。
 // 実行: node --test packages/overlay-runtime/test-harness/full-frame-background-clip.test.mjs
 import assert from "node:assert/strict";
-import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -25,7 +18,9 @@ const BACKGROUND = [0, 128, 255];
 function loadPuppeteer() {
   const roots = [resolve(HERE, "../../render-cut")];
   const gitFile = resolve(HERE, "../../../.git");
-  if (existsSync(gitFile)) {
+  // .git は git worktree では「gitdir: ...」を書いたファイル、通常の clone では
+  // ディレクトリ。existsSync だけで通すと clone 側で readFileSync が EISDIR で落ちる。
+  if (existsSync(gitFile) && statSync(gitFile).isFile()) {
     const gitDir = readFileSync(gitFile, "utf8").trim().replace(/^gitdir:\s*/, "");
     const marker = `${join(".git", "worktrees")}/`;
     const markerIndex = gitDir.indexOf(marker);

--- a/packages/overlay-runtime/test-harness/hit-policy.test.mjs
+++ b/packages/overlay-runtime/test-harness/hit-policy.test.mjs
@@ -2,7 +2,7 @@
 // document.body.dataset.testStatus が pass へ到達することを機械検証する。
 // 実行: node --test packages/overlay-runtime/test-harness/hit-policy.test.mjs
 import assert from "node:assert/strict";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -13,7 +13,9 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 function loadPuppeteer() {
   const roots = [resolve(HERE, "../../render-cut")];
   const gitFile = resolve(HERE, "../../../.git");
-  if (existsSync(gitFile)) {
+  // .git は git worktree では「gitdir: ...」を書いたファイル、通常の clone では
+  // ディレクトリ。existsSync だけで通すと clone 側で readFileSync が EISDIR で落ちる。
+  if (existsSync(gitFile) && statSync(gitFile).isFile()) {
     const gitDir = readFileSync(gitFile, "utf8").trim().replace(/^gitdir:\s*/, "");
     const marker = `${join(".git", "worktrees")}/`;
     const markerIndex = gitDir.indexOf(marker);

--- a/packages/overlay-runtime/test-harness/overlay-runtime-tick.test.mjs
+++ b/packages/overlay-runtime/test-harness/overlay-runtime-tick.test.mjs
@@ -3,6 +3,8 @@
 //     mount(summary, options) / configure() / createOverlayRuntime() で上書き・無効化できること
 // (b) 非 3D 断片の getAnimations({ subtree: true }) が 250ms 以内の連続 tick で 1 回しか
 //     呼ばれず、可視化フリップと 250ms 経過で引き直されること（[data-akari-active] ゲートは維持）
+// (c) 3D 断片でも同じ CSS アニメ同期を通すこと（three のシーンと断片の CSS は別物で、
+//     後者を進めるのは tick の仕事。回帰: 2026-09-04）
 // 実 DOM（CSS animation の生成・three の描画）は扱わない。実ブラウザでの挙動は
 // entry-animation-hit-region.test.mjs / premount.test.mjs が担う。
 // 実行: node --test packages/overlay-runtime/test-harness/overlay-runtime-tick.test.mjs
@@ -250,4 +252,44 @@ test("入場アニメの確定判定（hitPolicyPending）もキャッシュ済�
     1,
     "確定判定も pause/currentTime 同期と同じキャッシュを使い、getAnimations は 1 回",
   );
+});
+
+// 回帰（2026-09-04 実機報告「3D モデルがずっと画面に残る」）:
+// 3D 分岐が CSS アニメ同期の手前で continue していたため、3D 宣言を含む断片の CSS アニメが
+// 1 本も pause / currentTime されず、壁時計で走り切って animation-fill-mode の最終姿勢へ
+// 張り付いていた。実機の S4 断片は 3D ステージの出入りを 45 秒の CSS アニメだけで持って
+// いるので、最終姿勢 = 画面中央に居座る絵になっていた。
+// 書き出し（render-cut の rasterize.mjs）は __akariSyncAnimations を 3D コンテナにも等しく
+// 掛けているため、飛ばすとプレビューと書き出しで絵が食い違う。
+test("3D 断片の CSS アニメもタイムラインへ同期する（three の描画とは別口）", async () => {
+  const animation = {
+    paused: false,
+    currentTime: null,
+    pause() { this.paused = true; },
+    effect: { getComputedTiming: () => ({ endTime: 800 }) },
+  };
+  const host = createHost({ animations: () => [animation] });
+  await host.runtime.mount({ overlays: [{ id: "cube", start: 0, duration: 10, html: THREE_HTML }] });
+  const container = host.stage.children[0];
+  const cubeCalls = () => host.getAnimationsCalls.filter((call) => call.element === container).length;
+
+  host.clock = 1000;
+  host.runtime.tick(1.5, true);
+  assert.equal(animation.paused, true, "3D 断片の CSS アニメも pause する（壁時計で走らせない）");
+  assert.equal(animation.currentTime, 1500, "currentTime は断片のローカル時刻（= tick 時刻 - start）");
+  assert.equal(cubeCalls(), 1);
+  assert.deepEqual(own(host.getAnimationsCalls[0].options), { subtree: true });
+  assert.equal(host.renderCalls.length, 1, "CSS 同期を通しても three の描画は従来どおり呼ぶ");
+  assert.equal(host.renderCalls[0].seconds, 1.5);
+
+  // 壁時計を大きく進めてもタイムライン位置にだけ追従する
+  host.clock = 9000;
+  host.runtime.tick(3, true);
+  assert.equal(animation.currentTime, 3000, "壁時計ではなくタイムライン位置へ同期する");
+  assert.equal(cubeCalls(), 2, "250ms 超過で引き直すのは非 3D 断片と同じ");
+
+  // 巻き戻しても同じ（シークで過去へ戻す経路）
+  host.clock = 9300;
+  host.runtime.tick(0.5, true);
+  assert.equal(animation.currentTime, 500);
 });

--- a/packages/overlay-runtime/test-harness/pointer-events-hit-region.test.mjs
+++ b/packages/overlay-runtime/test-harness/pointer-events-hit-region.test.mjs
@@ -2,14 +2,7 @@
 // オーバーフローを含む描画ピクセルを欠損させないことを headless Chrome で検証する。
 // 実行: node --test packages/overlay-runtime/test-harness/pointer-events-hit-region.test.mjs
 import assert from "node:assert/strict";
-import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -24,7 +17,9 @@ const HEIGHT = 360;
 function loadPuppeteer() {
   const roots = [resolve(HERE, "../../render-cut")];
   const gitFile = resolve(HERE, "../../../.git");
-  if (existsSync(gitFile)) {
+  // .git は git worktree では「gitdir: ...」を書いたファイル、通常の clone では
+  // ディレクトリ。existsSync だけで通すと clone 側で readFileSync が EISDIR で落ちる。
+  if (existsSync(gitFile) && statSync(gitFile).isFile()) {
     const gitDir = readFileSync(gitFile, "utf8").trim().replace(/^gitdir:\s*/, "");
     const marker = `${join(".git", "worktrees")}/`;
     const markerIndex = gitDir.indexOf(marker);

--- a/packages/overlay-runtime/test-harness/resize-anchor.test.mjs
+++ b/packages/overlay-runtime/test-harness/resize-anchor.test.mjs
@@ -2,7 +2,7 @@
 // 任意で AKARI_RESIZE_EVIDENCE_PATH を渡すと、ログを含む最終画面を PNG 保存する。
 // 実行: node --test packages/overlay-runtime/test-harness/resize-anchor.test.mjs
 import assert from "node:assert/strict";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -14,7 +14,9 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 function loadPuppeteer() {
   const roots = [resolve(HERE, "../../render-cut")];
   const gitFile = resolve(HERE, "../../../.git");
-  if (existsSync(gitFile)) {
+  // .git は git worktree では「gitdir: ...」を書いたファイル、通常の clone では
+  // ディレクトリ。existsSync だけで通すと clone 側で readFileSync が EISDIR で落ちる。
+  if (existsSync(gitFile) && statSync(gitFile).isFile()) {
     const gitDir = readFileSync(gitFile, "utf8").trim().replace(/^gitdir:\s*/, "");
     const marker = `${join(".git", "worktrees")}/`;
     const markerIndex = gitDir.indexOf(marker);

--- a/packages/preview-server/public/app.js
+++ b/packages/preview-server/public/app.js
@@ -3635,30 +3635,39 @@ function createOverlayRuntime() {
         o.el.style.setProperty('--rotate', o.isBackground ? '0deg' : `${state.rotate}deg`);
         o.el.style.setProperty('opacity', String(state.opacity));
       }
-      if (o.is3d) {
-        if (!o.threeReady) continue;
-        // 3D 断片は three 側が時刻を持つ（mixer.setTime）。shell と同じく
-        // getAnimations ループは回さない — ここで continue する
-        window.akari?.threeRuntime?.render(o.el, ms / 1000, {
-          syncVideos: true,
-          maxRenderSize: PREVIEW_3D_MAX_RENDER_SIZE,
-        });
-        if (o.hitPolicyPending) {
-          window.akari.interaction?.applyOverlayHitPolicy?.(o.el);
-          o.hitPolicyPending = false;
-        }
-        continue;
-      }
       // getAnimations({subtree:true}) のコストは「ドキュメント全体に現存する CSS animation の
       // 総数」にほぼ比例する（overlay-runtime.js の注記。実測の地雷）。断片のアニメは
       // `[data-akari-active]` ゲートで宣言する規約なので、可視の間は顔ぶれが変わらない。
       // 毎フレーム引き直さず、可視化時と 250ms ごとだけ引き直す（遅れて生えるものも拾える）。
+      //
+      // 3D 断片も必ずここを通す。three のシーンは three 側が時刻を持つ（mixer.setTime）が、
+      // 断片の **CSS** アニメを進めるのは誰の仕事でもなくなる。以前はこの手前で continue して
+      // いたため、3D 宣言を含む断片の CSS アニメが 1 本も同期されず、壁時計で走り切って
+      // animation-fill-mode の最終姿勢に張り付いていた（実機報告 2026-09-04: S4 の 3D ステージが
+      // 画面中央に残り続ける。仕様は translate3d(142%) = 局所 7 秒まで画面外）。
+      // 書き出し（render-cut の rasterize.mjs）は __akariSyncAnimations を 3D コンテナにも
+      // 等しく掛けているので、ここで飛ばすとプレビューと書き出しで絵が食い違う。
       const nowMs = performance.now();
       if (!o._anims || nowMs - o._animsAt > 250) {
         o._anims = o.el.getAnimations({ subtree: true });
         o._animsAt = nowMs;
       }
       for (const a of o._anims) { a.pause(); a.currentTime = ms; }
+      if (o.is3d) {
+        // three の描画だけはランタイム読み込み後に始まる。CSS 側は上で同期済みなので、
+        // 読み込み待ちの間も断片の見た目はタイムラインに追従する。
+        if (o.threeReady) {
+          window.akari?.threeRuntime?.render(o.el, ms / 1000, {
+            syncVideos: true,
+            maxRenderSize: PREVIEW_3D_MAX_RENDER_SIZE,
+          });
+        }
+        if (o.hitPolicyPending) {
+          window.akari.interaction?.applyOverlayHitPolicy?.(o.el);
+          o.hitPolicyPending = false;
+        }
+        continue;
+      }
       if (o.hitPolicyPending) {
         window.akari.interaction?.applyOverlayHitPolicy?.(o.el);
         o.hitPolicyPending = false;

--- a/packages/preview-server/test/three-overlay-animation-sync.test.mjs
+++ b/packages/preview-server/test/three-overlay-animation-sync.test.mjs
@@ -1,0 +1,54 @@
+// 回帰（2026-09-04 実機報告「3D モデルがずっと画面に残る」）:
+// tick() の 3D 分岐が CSS アニメ同期の**手前**で continue していたため、3D 宣言を含む断片の
+// CSS アニメが 1 本も pause / currentTime されず、壁時計で走り切って animation-fill-mode の
+// 最終姿勢へ張り付いていた。実測した S4 断片は 3D ステージの出入りを 45 秒の CSS アニメだけで
+// 持っているので、最終姿勢 = 画面中央に居座る絵になっていた。
+//
+// 書き出し（render-cut の rasterize.mjs）は __akariSyncAnimations を 3D コンテナにも等しく
+// 掛けている。飛ばすとプレビューと書き出しで絵が食い違うため、ここは両者のパリティ条件。
+// shell 側（packages/overlay-runtime）の同じ不具合は
+// overlay-runtime/test-harness/overlay-runtime-tick.test.mjs が挙動で押さえている。
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const read = name => readFile(path.resolve(import.meta.dirname, '..', name), 'utf8');
+const [app, rasterize] = await Promise.all([
+  read('public/app.js'),
+  readFile(path.resolve(import.meta.dirname, '../../render-cut/src/rasterize.mjs'), 'utf8'),
+]);
+
+const tickBody = app.slice(app.indexOf('  function tick(t) {'), app.indexOf('  function applyProps(s) {'));
+
+test('tick: CSS アニメ同期を 3D 分岐より先に通す（3D 断片を同期から外さない）', () => {
+  const syncAt = tickBody.indexOf('for (const a of o._anims) { a.pause(); a.currentTime = ms; }');
+  const threeAt = tickBody.indexOf('if (o.is3d) {');
+  assert.ok(syncAt > 0, 'CSS アニメ同期のループが tick に無い');
+  assert.ok(threeAt > 0, '3D 分岐が tick に無い');
+  assert.ok(
+    syncAt < threeAt,
+    '3D 分岐が CSS アニメ同期より前にあると、3D 宣言を含む断片の CSS アニメが壁時計で走る',
+  );
+});
+
+test('tick: CSS 同期を通したうえで three の描画も従来どおり呼ぶ', () => {
+  const threeBranch = tickBody.slice(tickBody.indexOf('if (o.is3d) {'));
+  assert.match(threeBranch, /threeRuntime\?\.render\(o\.el, ms \/ 1000, \{/u);
+  assert.match(threeBranch, /maxRenderSize: PREVIEW_3D_MAX_RENDER_SIZE/u);
+});
+
+test('tick: three ランタイム読み込み待ちでも CSS 同期は止めない', () => {
+  // 旧実装の `if (!o.threeReady) continue;` は、ランタイムが揃うまで断片ごと素通しにしていた。
+  const threeBranch = tickBody.slice(tickBody.indexOf('if (o.is3d) {'));
+  assert.doesNotMatch(threeBranch, /if \(!o\.threeReady\) continue;/u);
+  assert.match(threeBranch, /if \(o\.threeReady\)/u);
+});
+
+test('書き出し側は 3D コンテナも同じ __akariSyncAnimations に掛ける（パリティの根拠）', () => {
+  const seek = rasterize.slice(rasterize.indexOf('window.__akariSeek = async function(seconds)'));
+  const loopEnd = seek.indexOf('window.__akariSyncAnimations(seconds);');
+  assert.ok(loopEnd > 0, '__akariSeek が __akariSyncAnimations を呼んでいない');
+  // 3D コンテナは pendingThreeDraws へ積むだけで、continue も除外もしない
+  assert.doesNotMatch(seek.slice(0, loopEnd), /continue;/u);
+});


### PR DESCRIPTION
## 症状

プレビューで、S4「3Dは、AIの得意分野」の 3D モデル（ノート PC）が章の頭から最後まで画面中央に居座る。仕様では局所 0〜7 秒は画面右外にいて、C26 で右から滑り込んでくる。

Electron シェル・Web UI の両方で再現する。**書き出しは正しい**ので、プレビュー側だけが誤っているパリティ不整合。

## 原因

`tick()` の 3D 分岐が CSS アニメ同期の**手前**で `continue` していた。

```js
if (o.is3d) {
  if (!o.threeReady) continue;
  window.akari?.threeRuntime?.render(o.el, ms / 1000, {...});
  continue;                                   // ← ここで抜ける
}
const nowMs = performance.now();              // ← 3D 断片は到達しない
...
for (const a of o._anims) { a.pause(); a.currentTime = ms; }
```

three のシーンは three 側が時刻を持つ（`mixer.setTime`）が、**断片の CSS アニメを進めるのは `tick` の仕事**で、飛ばすと誰もやらなくなる。結果、3D 宣言を含む断片の CSS アニメが 1 本も `pause` / `currentTime` されず壁時計で走り、`animation-fill-mode: both` の断片は走り切ったあと最終姿勢に張り付く。

S4 断片（`overlays/s4-3d-climax.html`）は 3D ステージの出入りを 45 秒の CSS アニメだけで持っている。

```css
.s4__stage3d {
  transform: translate3d(-5%, 1%, 0) scale(1);   /* base = 最終静止状態 = 画面内 */
  animation-name: s4-stage; animation-duration: 45s; animation-fill-mode: both;
}
@keyframes s4-stage {
  0%      { transform: translate3d(142%, -6%, 0) ... }  /* 画面右外 */
  15.556% { transform: translate3d(142%, -6%, 0) ... }  /* = 局所 7.0 秒まで画面外 */
  ...
}
```

最終キーフレームが画面内なので、45 秒ぶん流れ切った時点で画面中央に固定される。これが「ずっと残る」の機序。

書き出し（`render-cut/src/rasterize.mjs`）は `__akariSyncAnimations` を 3D コンテナにも等しく掛けており、除外していない。プレビューだけが飛ばしていた。

## 修正

3D 分岐を CSS アニメ同期の**後ろ**へ移す。three の描画・当たり判定・250ms キャッシュの挙動は変えていない。

- `packages/overlay-runtime/src/overlay-runtime.js`（Electron シェル）
- `packages/preview-server/public/app.js`（Web UI）

ついでに `if (!o.threeReady) continue;` を `if (o.threeReady)` へ変え、three ランタイム読み込み待ちの間も CSS 側がタイムラインへ追従するようにした（従来はロード完了まで断片ごと素通し）。シェル側の 3D 分岐は `entryAnimationsSettled()` をキャッシュ済み一覧で引くようになり、`getAnimations()` の呼び出しはむしろ減る。

## 実測

`.s4__stage3d` の computed transform と `s4-stage` の状態。Electron シェル・Web UI で同値。

| 局所時刻 | 修正前 | 修正後 | 仕様 |
|---|---|---|---|
| 0.5s | `translateX(-14.4px)` 画面内 / ct=39053 `running` | `translateX(2726.4px)` / ct=**500 paused** | 142% = 画面外 |
| 5.0s | `-69.5px` / ct=43070 `running` | `2726.4px` / ct=**5000 paused** | 画面外 |
| 9.0s | `-96px` / ct=**45000 finished** | `134.4px` / ct=**9000 paused** | 20% キーフレーム |
| 32.0s | `-96px` / ct=45000 `finished` | `scale(1.08)`, `-1%` / ct=**32000 paused** | 71.111% キーフレーム |

断片内 135 本のアニメが `paused` **0 本 → 135 本**。対照として非 3D 断片（`s3-captions`）は修正前から正しく `paused` で、3D 断片だけが同期から漏れていた。

局所 0.5 秒（C24「暗転 → 床グリッドが敷き詰まる」）の実機の絵は、修正前がノート PC 居座り、修正後は床グリッドのみ。

## 回帰テスト

この不具合が通ったのは「3D 宣言を含む断片の CSS アニメがタイムラインへ同期される」ことを検める試験が無かったため。既存の 55 本はパッチ前後どちらも通ってしまう。

- `packages/overlay-runtime/test-harness/overlay-runtime-tick.test.mjs`（シェル / 挙動）— 既存の vm フェイク DOM に 1 本追加。3D 断片を tick して `pause` と `currentTime` = ローカル時刻を確認し、壁時計を大きく進めても・巻き戻してもタイムライン位置にだけ追従することと、three の描画が従来どおり呼ばれることを併せて見る。
- `packages/preview-server/test/three-overlay-animation-sync.test.mjs`（Web UI / ソース検査）— `app.js` は browser module で vm に載らないため、既存の `web-ui-parity-2026-09` と同じ流儀で `tick` 内の並び（CSS 同期 → 3D 分岐）を検める。書き出し側の `__akariSyncAnimations` が 3D コンテナを除外していないことも同じ試験で押さえ、パリティの根拠を 1 箇所にまとめた。

いずれも修正を revert すると落ちることを確認済み。

## 同梱: テストハーネスの `.git` 判定（3 コミット目）

`loadPuppeteer()` が `.git` をファイル前提で `readFileSync` していた。git worktree では「gitdir: ...」を書いたファイルだが、**通常の clone ではディレクトリ**なので `EISDIR` で落ちる。`existsSync` はディレクトリにも true を返すため素通りしていた。

この throw は `loadPuppeteer` の先頭にあり本来のフォールバックへ進む前に投げるので、clone 環境ではブラウザを使う試験が 10 件まるごと落ちていた。`statSync(gitFile).isFile()` のガードを 6 ファイルに足した。worktree 側の挙動は変わらない。

- 修正前（clone 環境）: 45 pass / 10 fail
- 修正後: **56 pass / 0 fail**（回帰テスト 1 本を含む）

## 確認環境

macOS arm64 / Node 20.20.2 / Electron 39.8.7。`apps/shell` を本番ビルド（`npm run build`）した開発版シェルを Playwright で駆動し、実際にプロジェクトを開いてプレビューで計測。シェルは `overlay-runtime.js` をバンドルせず実行時にディスクから読む（`akari-preview-service.ts:334`）ため、同一ビルドのままファイルを差し替えて修正前後を比較した。

## 同梱: resign-electron が hoist された electron を見つけられない（4 コミット目）

`apps/shell/scripts/resign-electron.mjs` が electron の場所を `apps/shell/node_modules/electron` 固定で組んでいた。npm workspaces は electron を monorepo ルートへ hoist するため、この配置では通常存在せず、「electron devDependency 未インストールの可能性 — スキップ」と誤判定して黙って何もしない。**postinstall / postbuild から呼んでも再署名は一度も走っていなかった。**

`require.resolve` は `shellRoot` から `node_modules` を遡るので、ネスト配置と hoist のどちらでも当たる。解決失敗と「解決できたが dist がまだ無い」を別メッセージに分けた（どちらも従来どおりスキップして exit 0）。

検証（macOS arm64 / `npm ci` 済みの clone / electron 39.8.7 がルートへ hoist された配置）:

- 修正前: `node_modules/electron/dist/Electron.app が見つかりません — スキップ`（実際にはルート側に存在する）
- 修正後: `OK — ../../node_modules/electron/dist/Electron.app をアドホック再署名しました`
- `libffmpeg.dylib` を書き換えて署名を壊す（`codesign --verify` が `a sealed resource is missing or invalid`）→ 本スクリプト → `codesign --verify --deep --strict` が valid、まで往復で確認

なお、このファイル冒頭の注記が述べる「署名不正だと Apple Silicon で無言 kill される」症状自体は、今回の作業では**再現していない**。署名が invalid と報告される状態でも開発ビルドは起動した（本作業で遭遇した無言終了は、起動中の `/Applications/AKARI Video.app` との `requestSingleInstanceLock` 衝突が原因で、署名とは無関係だった）。この PR が直すのは「スクリプトが黙ってスキップされる」ところまで。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
