### PR TITLE
[修正] frame-engine 生成物の codegen drift を required レーンで必ず検出する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
       # ローカル実測 2026-09-02（macOS arm64・Node 26.3.0）: added 1480 packages / 7 s（キャッシュ有）。
       - name: Install workspace dependencies (repo root, npm ci --ignore-scripts)
         run: npm ci --ignore-scripts --no-audit --no-fund
+      - name: check frame-engine bundle drift (3 consumers)
+        run: node scripts/ci/check-frame-engine-drift.mjs
       - name: unit tests (lane pure)
         run: node scripts/ci/run-unit-tests.mjs --lane pure
 
@@ -135,6 +137,14 @@ jobs:
           node-version: '26.3.0'
           cache: npm
           cache-dependency-path: apps/shell/package-lock.json
+
+      # frame-engine の再バンドルには repoRoot の node_modules が必要。CI の drift 検査を
+      # 依存不足で skip させず実行するため、shell 側とは別にルート依存も用意する。
+      # root の npm ci は workspaces を reify して apps/shell/node_modules を空にするため、
+      # 必ず shell install より前に置く（2026-09-04 実測: 804 → 1 エントリ）。
+      - name: Install workspace dependencies for frame-engine drift check (repo root)
+        working-directory: ${{ github.workspace }}
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       # apps/shell/package-lock.json は 2026-08-19 から追跡対象（apps/shell/.gitignore 参照）なので
       # `npm ci` を使う（2026-09-02 に `npm install` から切替。`npm install` はその日のレジストリで

--- a/apps/shell/extensions/akari-preview/package.json
+++ b/apps/shell/extensions/akari-preview/package.json
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "bundle:frame-engine": "node scripts/bundle-frame-engine.mjs",
+    "check:frame-engine-drift": "node scripts/bundle-frame-engine.mjs --check",
     "build": "node scripts/bundle-frame-engine.mjs && tsc -b",
     "clean": "rimraf lib",
     "test": "tsc -b && node --test test/*.test.mjs"

--- a/apps/shell/extensions/akari-preview/scripts/bundle-frame-engine.mjs
+++ b/apps/shell/extensions/akari-preview/scripts/bundle-frame-engine.mjs
@@ -1,8 +1,7 @@
 import { existsSync } from 'node:fs';
-import { mkdir, rename, rm } from 'node:fs/promises';
+import { mkdir, readFile, rename, rm } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 const extensionRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -12,6 +11,7 @@ const outputDirectory = path.join(extensionRoot, 'generated');
 const output = path.join(outputDirectory, 'frame-engine.js');
 const temporaryOutput = path.join(outputDirectory, 'frame-engine.js.tmp');
 const entry = path.join(repoRoot, 'packages', 'frame-engine', 'src', 'index.ts');
+const check = process.argv.includes('--check');
 const require = createRequire(import.meta.url);
 
 function oneLine(value) {
@@ -22,18 +22,24 @@ function skip(reason) {
   console.log(`[bundle-frame-engine] skipped: ${oneLine(reason)}`);
 }
 
-let esbuild;
+let buildSync;
 try {
-  esbuild = require.resolve('esbuild/bin/esbuild');
+  ({ buildSync } = require('esbuild'));
 } catch {
   const candidates = [
-    path.join(repoRoot, 'node_modules', 'esbuild', 'bin', 'esbuild'),
-    path.join(shellRoot, 'node_modules', 'esbuild', 'bin', 'esbuild')
+    path.join(repoRoot, 'node_modules', 'esbuild'),
+    path.join(shellRoot, 'node_modules', 'esbuild')
   ];
-  esbuild = candidates.find(candidate => existsSync(candidate));
+  for (const candidate of candidates) {
+    try {
+      ({ buildSync } = require(candidate));
+      break;
+    } catch {}
+  }
 }
 
-if (!esbuild) {
+if (!buildSync) {
+  if (check) throw new Error('esbuild が見つかりません');
   skip('esbuild が見つかりません');
   process.exit(0);
 }
@@ -41,23 +47,41 @@ if (!esbuild) {
 await mkdir(outputDirectory, { recursive: true });
 await rm(temporaryOutput, { force: true });
 const banner = '// このファイルは生成物です。正本は packages/frame-engine/src、再生成は npm run bundle:frame-engine。';
-const result = spawnSync(process.execPath, [
-  esbuild,
-  entry,
-  '--bundle',
-  '--format=iife',
-  '--global-name=AkariFrameEngine',
-  '--platform=browser',
-  '--target=chrome122',
-  `--banner:js=${banner}`,
-  `--outfile=${temporaryOutput}`
-], { cwd: repoRoot, encoding: 'utf8' });
-
-if (result.status !== 0 || !existsSync(temporaryOutput)) {
+try {
+  buildSync({
+    entryPoints: [entry],
+    bundle: true,
+    format: 'iife',
+    globalName: 'AkariFrameEngine',
+    platform: 'browser',
+    target: ['chrome122'],
+    banner: { js: banner },
+    absWorkingDir: repoRoot,
+    outfile: temporaryOutput,
+    logLevel: 'silent'
+  });
+} catch (error) {
   await rm(temporaryOutput, { force: true });
-  skip(result.stderr || result.error?.message || `esbuild exit ${result.status}`);
+  if (check) throw error;
+  skip(error?.message);
+  process.exit(0);
+}
+if (!existsSync(temporaryOutput)) {
+  if (check) throw new Error('esbuild が出力を生成しませんでした');
+  skip('esbuild が出力を生成しませんでした');
   process.exit(0);
 }
 
-await rename(temporaryOutput, output);
-console.log(`[bundle-frame-engine] generated ${path.relative(repoRoot, output)}`);
+if (check) {
+  if (!existsSync(output) || !Buffer.from(await readFile(output)).equals(Buffer.from(await readFile(temporaryOutput)))) {
+    await rm(temporaryOutput, { force: true });
+    process.stderr.write('frame-engine bundle drift detected\n');
+    process.exitCode = 1;
+  } else {
+    await rm(temporaryOutput, { force: true });
+    process.stdout.write('frame-engine bundle is current\n');
+  }
+} else {
+  await rename(temporaryOutput, output);
+  console.log(`[bundle-frame-engine] generated ${path.relative(repoRoot, output)}`);
+}

--- a/apps/shell/extensions/akari-preview/test/frame-engine-preview.test.mjs
+++ b/apps/shell/extensions/akari-preview/test/frame-engine-preview.test.mjs
@@ -233,6 +233,9 @@ test('frame-engine bundle は生成元から再生成しても byte drift がな
     const rootNodeModules = join(repoRoot, 'node_modules');
     const esbuild = join(rootNodeModules, 'esbuild', 'bin', 'esbuild');
     if (!existsSync(rootNodeModules) || !existsSync(esbuild)) {
+        if (process.env.CI) {
+            assert.fail('CI ではリポジトリ直下の node_modules と esbuild が必須です');
+        }
         t.skip('リポジトリ直下の node_modules または esbuild が無いため drift 検査を省略');
         return;
     }

--- a/packages/gpu-export/scripts/bundle-frame-engine.mjs
+++ b/packages/gpu-export/scripts/bundle-frame-engine.mjs
@@ -1,4 +1,3 @@
-import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rename, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -14,21 +13,32 @@ const entry = join(repoRoot, "packages", "frame-engine", "src", "index.ts");
 const check = process.argv.includes("--check");
 const require = createRequire(import.meta.url);
 
-let esbuild;
-try { esbuild = require.resolve("esbuild/bin/esbuild"); }
-catch { esbuild = [join(repoRoot, "node_modules", "esbuild", "bin", "esbuild")].find(existsSync); }
-if (!esbuild) throw new Error("esbuild が見つかりません");
+let buildSync;
+try { ({ buildSync } = require("esbuild")); }
+catch { ({ buildSync } = require(join(repoRoot, "node_modules", "esbuild"))); }
 
 await mkdir(outputDirectory, { recursive: true });
 await rm(temporaryOutput, { force: true });
 const banner = "// このファイルは生成物です。正本は packages/frame-engine/src、再生成は npm run bundle:frame-engine。";
-const result = spawnSync(process.execPath, [
-  esbuild, entry, "--bundle", "--format=iife", "--global-name=AkariFrameEngine",
-  "--platform=browser", "--target=chrome122", `--banner:js=${banner}`, `--outfile=${temporaryOutput}`,
-], { cwd: repoRoot, encoding: "utf8" });
-if (result.status !== 0 || !existsSync(temporaryOutput)) {
+try {
+  buildSync({
+    entryPoints: [entry],
+    bundle: true,
+    format: "iife",
+    globalName: "AkariFrameEngine",
+    platform: "browser",
+    target: ["chrome122"],
+    banner: { js: banner },
+    absWorkingDir: repoRoot,
+    outfile: temporaryOutput,
+    logLevel: "silent",
+  });
+} catch (error) {
   await rm(temporaryOutput, { force: true });
-  throw new Error(result.stderr || result.error?.message || `esbuild exit ${result.status}`);
+  throw error;
+}
+if (!existsSync(temporaryOutput)) {
+  throw new Error("esbuild が出力を生成しませんでした");
 }
 if (check) {
   if (!existsSync(output) || !Buffer.from(await readFile(output)).equals(Buffer.from(await readFile(temporaryOutput)))) {

--- a/packages/osr-export/scripts/bundle-frame-engine.mjs
+++ b/packages/osr-export/scripts/bundle-frame-engine.mjs
@@ -1,4 +1,3 @@
-import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rename, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -14,23 +13,32 @@ const entry = join(repoRoot, "packages", "frame-engine", "src", "index.ts");
 const check = process.argv.includes("--check");
 const require = createRequire(import.meta.url);
 
-let esbuild;
-try { esbuild = require.resolve("esbuild/bin/esbuild"); }
-catch {
-  esbuild = [join(repoRoot, "node_modules", "esbuild", "bin", "esbuild")].find(existsSync);
-}
-if (!esbuild) throw new Error("esbuild が見つかりません");
+let buildSync;
+try { ({ buildSync } = require("esbuild")); }
+catch { ({ buildSync } = require(join(repoRoot, "node_modules", "esbuild"))); }
 
 await mkdir(outputDirectory, { recursive: true });
 await rm(temporaryOutput, { force: true });
 const banner = "// このファイルは生成物です。正本は packages/frame-engine/src、再生成は npm run bundle:frame-engine。";
-const result = spawnSync(process.execPath, [
-  esbuild, entry, "--bundle", "--format=iife", "--global-name=AkariFrameEngine",
-  "--platform=browser", "--target=chrome122", `--banner:js=${banner}`, `--outfile=${temporaryOutput}`,
-], { cwd: repoRoot, encoding: "utf8" });
-if (result.status !== 0 || !existsSync(temporaryOutput)) {
+try {
+  buildSync({
+    entryPoints: [entry],
+    bundle: true,
+    format: "iife",
+    globalName: "AkariFrameEngine",
+    platform: "browser",
+    target: ["chrome122"],
+    banner: { js: banner },
+    absWorkingDir: repoRoot,
+    outfile: temporaryOutput,
+    logLevel: "silent",
+  });
+} catch (error) {
   await rm(temporaryOutput, { force: true });
-  throw new Error(result.stderr || result.error?.message || `esbuild exit ${result.status}`);
+  throw error;
+}
+if (!existsSync(temporaryOutput)) {
+  throw new Error("esbuild が出力を生成しませんでした");
 }
 if (check) {
   if (!existsSync(output) || !Buffer.from(await readFile(output)).equals(Buffer.from(await readFile(temporaryOutput)))) {

--- a/scripts/ci/check-frame-engine-drift.mjs
+++ b/scripts/ci/check-frame-engine-drift.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const checks = [
+  ['packages/gpu-export', 'packages/gpu-export/scripts/bundle-frame-engine.mjs'],
+  ['packages/osr-export', 'packages/osr-export/scripts/bundle-frame-engine.mjs'],
+  ['apps/shell/extensions/akari-preview', 'apps/shell/extensions/akari-preview/scripts/bundle-frame-engine.mjs']
+];
+const failed = [];
+
+for (const [name, script] of checks) {
+  process.stdout.write(`[frame-engine-drift] checking ${name}\n`);
+  const result = spawnSync(process.execPath, [path.join(repoRoot, script), '--check'], {
+    cwd: repoRoot,
+    encoding: 'utf8'
+  });
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  if (result.status !== 0) {
+    failed.push(name);
+    process.stderr.write(`[frame-engine-drift] failed: ${name} (exit ${result.status ?? 'unknown'})\n`);
+  }
+}
+
+if (failed.length > 0) {
+  process.stderr.write(`[frame-engine-drift] drift check failed: ${failed.join(', ')}\n`);
+  process.exitCode = 1;
+} else {
+  process.stdout.write('[frame-engine-drift] all frame-engine bundles are current\n');
+}


### PR DESCRIPTION
v0.1.38 の発車直前に、プレビューの `generated/frame-engine.js` が正本から 2 世代ぶん古いまま main に載っているのを発見した（生成物は `b631e044` で是正済み）。本 PR は**それを許した仕組みの側**を直す。

## 何が壊れていたか

検出器は 3 つあるのに、実質どれも効いていなかった。

1. **CI 接続がゼロ** — `grep -rn "frame-engine-drift" .github/ scripts/` = 0 件。`gpu-export` / `osr-export` には `--check` があるのに、ワークフローから一度も呼ばれていなかった
2. **`akari-preview` には `--check` 自体が無い** — 代わりの node テストは、リポ直下の `node_modules`/esbuild が無いと `t.skip`。shell レーンは `apps/shell` で `npm ci --no-workspaces` するので **CI では常に skip**。これで 2 コミットぶん腐った
3. **残る 2 つも install 形状しだいで起動しない** — `require.resolve("esbuild/bin/esbuild")` の結果を `spawnSync(process.execPath, ...)` に渡すが、esbuild 0.24 の `bin/esbuild` はネイティブバイナリのことがあり、node に食わせると `SyntaxError`。実測で `check:frame-engine-drift` が drift ではなく起動失敗で exit 1

## 直したこと

- 3 つの `bundle-frame-engine.mjs` を esbuild の **JS API（`buildSync`）** へ。**出力バイト列は不変**（3 生成物とも再生成後の sha256 が `be85ba77…` で一致）
- `akari-preview` に `check:frame-engine-drift` を追加し、3 者の非対称を解消
- `akari-preview` の `--check` を **fail-closed** 化（esbuild 不在を skip + exit 0 で緑にしない）
- drift テストは **CI では skip せず fail**（skip 条件は 1 文字も広げていない）
- **CI 接続（加算のみ）**: required の `unit` に `scripts/ci/check-frame-engine-drift.mjs`（3 本まとめ・実測 0.61 秒）、required の `l0` に再バンドル用の root 依存 install

## 実測

| 検査 | 結果 |
|---|---|
| 無改変 | 3 つとも `bundle is current` / **exit 0** |
| `packages/frame-engine/src` を 1 行汚す | 3 つとも `drift detected` / **exit 1** |
| esbuild bin が Mach-O バイナリの形状 | 修正前 exit 1（起動失敗）→ 修正後 **exit 0**。JS シム形状でも同結果 |
| `CI=1` + root `node_modules` 無し | skip ではなく **fail**（skipped 0） |
| shell レーン 4 数値 | 起点・本ブランチとも **2086 / 2086 / 0 / 0**（pass は 1 件も減っていない） |

`generated/frame-engine.js` 3 つと正本 `packages/frame-engine/src` は**無改変**。`ci.yml` は削除 0 行・`continue-on-error` 0・`if:` 0 の**加算 10 行のみ**。

## 申し送り

同型の穴がほかにもある疑い: `packages/pen-visuals/lib/`（追跡済み生成物・ゲート無し）/ `preview-server` の public bundle 4 本 / `edit-store` の generated 2 本。今回の `check-frame-engine-drift.mjs` は対象を配列で足すだけの形なので、棚卸し票で相乗りできる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1d4bgKdQ5Tr7bz5UDQnfz