### PR TITLE
[修正] 時間窓の外の overlay が GPU 経路で描かれる — visibility ではなく display で落とす (refs #53)

### DIFF
--- a/packages/gpu-export/src/page-runtime.js
+++ b/packages/gpu-export/src/page-runtime.js
@@ -1868,11 +1868,22 @@
       const started = performance.now();
       for (const { entry, container, itemKeyframes } of record.containers) {
         const active = activeAt(entry, seconds);
+        // 時間窓の外は display: none で落とす。visibility: hidden は継承するだけなので、
+        // 子孫が visibility: visible を再宣言すると打ち消される — 実制作の断片は
+        // 「基本 hidden・ゲートアニメの 0% が visible」という書き方をするため、非活性の
+        // コンテナで 0% を適用した瞬間に中身が見えてしまう（実測: s35 の B ロール写真が
+        // 配置 110s なのに 0s のフレームへ出た）。display: none は子孫から打ち消せない。
+        // 断片側も同じ意図のガード（:not([data-akari-active]) > .x { display: none !important }）
+        // を持つが、そちらは直下セレクタなので .scene-content を挟む構造では当たらない。
+        // issue #53 (a)
+        container.style.display = active ? "" : "none";
         container.style.visibility = active ? "visible" : "hidden";
         container.toggleAttribute("data-akari-active", active);
         // 活性・非活性を問わず毎コマ止めて時刻を書く。非活性を飛ばすと、時間窓の外の断片の
         // CSS アニメが壁時計で走り切り（書き出しは分単位）、fill-mode: both/forwards の姿勢に
         // 張り付いたまま窓に入ってくる = 同じ時刻でも直前に何を撮ったかで絵が変わる。
+        // display: none の間は CSS アニメ自体が動かないので固定は不要だが、活性へ戻った
+        // フレームで必ずこの行を通るため、時刻の書き込みは同じ 1 か所に残す。
         // OSR の __akariSyncAnimations は active 判定を持たず全コンテナを固定している
         // （render-cut/src/rasterize.mjs）。issue #53 (a)
         for (const animation of container.getAnimations({ subtree: true })) {

--- a/packages/gpu-export/test/osr-parity.test.mjs
+++ b/packages/gpu-export/test/osr-parity.test.mjs
@@ -72,6 +72,26 @@ test("(a) DOM 層は非活性コンテナのアニメも毎コマ止めて時刻
   assert.match(syncAnimations, /querySelectorAll\('\.akari-overlay-container'\)/u);
 });
 
+test("(a) 時間窓の外のコンテナは display で落とす（visibility だけでは子孫に打ち消される）", () => {
+  const captureRun = pageRuntimeSource.slice(
+    pageRuntimeSource.indexOf("async captureRun(run, seconds, frameNumber)"),
+    pageRuntimeSource.indexOf("recordFrameCost(value)"),
+  );
+  // visibility は継承するだけで、子孫の visibility: visible に打ち消される。実制作の断片は
+  // 「基本 hidden・ゲートアニメの 0% が visible」と書くため、非活性コンテナでその 0% を
+  // 適用した瞬間に中身が出る（実測: 配置 110s の B ロールが 0s のフレームへ 3 枚出た）。
+  // display: none は子孫から打ち消せないので、こちらを必ず併せて書くこと。issue #53 (a)
+  assert.match(captureRun, /container\.style\.display = active \? "" : "none";/u);
+  assert.match(captureRun, /container\.style\.visibility = active \? "visible" : "hidden";/u);
+  const displayIndex = captureRun.indexOf("container.style.display");
+  const pinIndex = captureRun.indexOf("container.getAnimations({ subtree: true })");
+  assert.ok(displayIndex >= 0 && pinIndex >= 0);
+  assert.ok(
+    displayIndex < pinIndex,
+    "display の切り替えはアニメ固定より手前で行うこと（活性へ戻ったフレームで先にボックスを作る）",
+  );
+});
+
 test("(c) 動画テクスチャのシークは 1 実装をシートから共有する", () => {
   assert.match(rasterizeSource, /window\.__akariSeekVideos = async function\(seconds\)/u);
   assert.match(rasterizeSource, /const warnings = await window\.__akariSeekVideos\(seconds\);/u);


### PR DESCRIPTION
## 何を直したか

配置 110 秒の B ロール断片の写真が、**0 秒目のフレームに 3 枚映っていました**。#53 で報告した「時間窓の外のオーバーレイが描画される」そのもので、2c0dc4d9 の対策後も残っていたものです。

実機で再現・原因特定・修正・実測まで通しています。

<details>
<summary>修正前の frame 0（配置 110s の B ロールが 3 枚映っている）</summary>

`s35-pic--br-rainy-street` / `br-train-window` / `br-monitor-glow` の 3 枚。台本では真っ暗から始まる地点です。

</details>

## 原因

DOM 層は非活性コンテナを `visibility: hidden` で隠していましたが、**visibility は継承するだけで、子孫が `visibility: visible` を再宣言すると打ち消されます。**

実制作の断片は「基本は hidden、ゲートアニメの 0% が visible」という書き方をします。

```css
.s35-cut--b1 { opacity: 0; visibility: hidden; animation: s35-gate-b1 34s linear both; }
@keyframes s35-gate-b1 { 0% { opacity: 1; visibility: visible; } ... }
```

2c0dc4d9 で入れた「非活性コンテナのアニメも毎コマ止めて時刻を書く」は、時刻を `max(0, seconds - start) * 1000` で書くため、**窓の外では必ず `currentTime = 0`** になります。つまり 0% の `visibility: visible` が確定し、コンテナの hidden を打ち消していました。壁時計で走らせない意図は正しいのですが、隠し方が足りていませんでした。

実測で裏を取っています（非活性コンテナの計算済みスタイルを frame 0 で走査）。

```
LEAK overlay s35-broll-generate (start=110) 非活性なのに可視 5 個
  div.s35-cut--b1                                    opacity=1      1920x1080
  div.s35-card ... s35-pic--br-rainy-street  ghost    opacity=0.857  277x175
  div.s35-card ... s35-pic--br-train-window  ghost    opacity=1      295x182
  div.s35-card ... s35-pic--br-monitor-glow  ghost    opacity=1      311x187
  span                                               opacity=1      1802x101
```

なお断片側も同じ意図のガードを持っていますが、**直下セレクタなので `.scene-content` を挟む現行の構造では GPU・OSR とも当たらず、事実上の死にコード**になっています。

```css
[data-overlay-id]:not([data-akari-active]) > .s35,
.akari-overlay-container:not([data-akari-active]) > .s35 { display: none !important; }
```

### OSR が正しく隠せていた理由

シートが CSS アニメを WAAPI クローンへ移す際、`effect.getTiming()` の fill をそのまま渡しています。CSS アニメの `getTiming()` は `fill: "auto"`（`animate()` では none に解決）を返すため、窓の外でクローンが何も塗らず、基本宣言の hidden が残ります。

裏を返すと **OSR は `animation-fill-mode` の意味を落としている**ことになるので、そちらは別途詰める価値があります（本 PR の範囲外）。

## 対応

`display: none` は子孫から打ち消せないので、非活性コンテナはこれで落とします。visibility の切り替えは既存の意味づけとして残しました。display の切り替えはアニメ固定より手前に置いています（活性へ戻ったフレームで先にボックスを作るため）。

## 実測

実案件（244 秒 / 7,320 コマ / 1920×1080 / overlay 9 本）を同じ `edit.json` から GPU と OSR で焼き、全コマの YMAX を比較しました。

| | 修正前 | **修正後** |
|---|---|---|
| 差 80 以上のコマ | 169 / 7,320（2.31%） | **1 / 7,320（0.01%）** |
| 乖離区間 | 21 本 | **1 本** |
| 平均差 | 11.63 | 8.20 |
| 最大差 | 180 | 95 |

- **(a) 0 秒目** — OSR 40 / GPU 220 → **GPU 40（完全一致）**
- **(b) 0.5 秒刻みの 12 点**（90.47〜95.97s）— 差 119〜125 → **2〜8**
- **(c) 数秒単位の区間**（13.47-14.00 / 50.17-53.30 / 102.80-103.37s）— **消滅**

**#53 の (a)(b)(c) は別々の原因ではなく、これ 1 つでした。** カット境界で単一コマだけ食い違って見えたのは、OSR が暗くなる瞬間に漏れた明るい画素が乗っていたためです。#53 で疑った µs 量子化は関係していませんでした（2c0dc4d9 の (b) 対策自体は OSR との式の統一として妥当なので、そのままです）。

`verify.blank-frames` の報告も OSR と一致するようになりました。**修正前の GPU が 0 件だったのは、漏れた画素が本来暗い区間を埋めていたから**で、警告が出ないほうが異常でした。

| | 修正前 GPU | 修正後 GPU | OSR |
|---|---|---|---|
| blank-frames | 0 件 | 13.367–14.033 / 50.2–53.633 / 102.767–103.433 / 144–144.5 / 145.333–145.633 | 13.367–14.033 / 50.167–53.333 / 102.733–103.433 / 144–144.433 |

### 副次的に #52 のメモリにも効きました

窓の外の 8 本ぶんのサブツリーがレイアウトから外れるためです。

| | 修正前 | 修正後 |
|---|---|---|
| RSS ピーク | 4.04 GiB（`hardStopExceeded: true`） | **2.30 GiB（false）** |
| Electron 稼働 | 308 秒 | **187 秒** |

修正前は既定の 4 GiB 上限を越えており、完走できていたのは超過の瞬間がレンダーループの外（チェックポイントが続かない mux 段）だったからで、余裕がありませんでした。本 PR でその余裕が戻ります。

## 残っている差

**0.133 秒（f4）の 1 コマだけ差 95 で残ります**（OSR 179 / GPU 84）。冒頭フェードインの途中で GPU が 1 コマ遅れて見えます。件数が桁で減ったことで初めて見えた本物の症状と考えており、別票で追います。

## テスト

- `gpu-export` **246 / 246**（新規 1 本を含む）
- 追加したのは `osr-parity.test.mjs` の「時間窓の外のコンテナは display で落とす」。`display` の切り替えがアニメ固定より手前にあることも合わせて押さえています

🤖 Generated with [Claude Code](https://claude.com/claude-code)
